### PR TITLE
Shape Context Descriptor Base Implementation

### DIFF
--- a/modules/algo_util.py
+++ b/modules/algo_util.py
@@ -89,17 +89,17 @@ def get_nms_bounding_boxes(
     contours: np.ndarray,
     confidences: np.ndarray,
     confidence_threshold: float,
-    nms_threshold: float,
+    nms_threshold: float = 0.9,
 ) -> List[BoundingBox]:
   """Returns bounding boxes after filtering through non-max suppression.
 
   Arguments:
-      contours: list of contours to filter. 
+      contours: list of contours (which is a list of x,y points) to filter.
       confidences: confidence scores associated with each contour.
       confidence_threshold: only keep bboxes with
-       confidence scores above this threshold.
-      nms_threshold: two bboxes with an IOU greater
-       than this threshold are considered the same bbox.
+       confidence scores (strictly) above this threshold.
+      nms_threshold: two bboxes with an IOU >=
+       this threshold are considered the same bbox. (default: 0.9)
 
   Returns:
       List of BoundingBoxes that passed the filter.

--- a/modules/algo_util.py
+++ b/modules/algo_util.py
@@ -7,8 +7,8 @@ import numpy as np
 import sklearn.cluster
 
 
-def shape_context_descriptor(icon_contour: List[List[List[int]]],
-                             img_contour: List[List[List[int]]]) -> float:
+def shape_context_descriptor(icon_contour: np.ndarray,
+                             img_contour: np.ndarray) -> float:
   """Calculates the shape context distance bewteen two contours.
 
   Arguments:
@@ -35,8 +35,7 @@ def detect_contours(image: np.ndarray,
        to smooth out edges before Canny edge detection.
 
   Returns:
-      List[List[List]]: List of contour groups,
-       each of which is a list of points.
+      List of contour groups,each of which is a list of points.
   """
   imgray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
   if use_bilateral_filter:
@@ -48,13 +47,14 @@ def detect_contours(image: np.ndarray,
 
 
 def cluster_contours_dbscan(
-    img_contours: List[List[int]],
+    img_contours: np.ndarray,
     eps: float = 10,
-    min_samples: int = 5) -> Tuple[List[List[List[int]]], List[List[bool]]]:
+    min_samples: int = 5) -> Tuple[List[np.ndarray], List[np.ndarray]]:
   """Group contours using DBSCAN.
 
   Arguments:
-      img_contours: Flattened list of points in the contour of an image.
+      img_contours: Flattened list of all points in all contours of an image.
+      That is: List[List[int]]
       eps: The maximum distance a point can be away to be considered
        within neighborhood of another point. (default: {10})
       min_samples: The number of points needed within a neighborhood
@@ -63,7 +63,8 @@ def cluster_contours_dbscan(
   Returns:
       List of groups of points, each representing its own contour,
        and a masked list of groups of bool values, each representing
-        which points are core points or not.
+        which points are core points or not. The contours and masks
+        are np.ndarrays of roughly List[List[int]] and List[bool].
   """
   clusters = sklearn.cluster.DBSCAN(eps=eps,
                                     min_samples=min_samples).fit(img_contours)

--- a/modules/algorithms.py
+++ b/modules/algorithms.py
@@ -7,14 +7,14 @@ import numpy as np
 import sklearn.cluster
 
 
-def shape_context_descriptor(icon_contour: np.ndarray,
-                             img_contour: np.ndarray) -> float:
+def shape_context_distance(icon_contour: np.ndarray,
+                           image_contour: np.ndarray) -> float:
   """Calculates the shape context distance bewteen two contours.
 
   Arguments:
       icon_contour: A list with shape (n, 1, 2).
        Represents the template icon contour
-      img_contour: A list with shape (n, 1, 2).
+      image_contour: A list with shape (n, 1, 2).
        Represents the image patch contour.
        (Note: function will fail unless the number of channels is 2.)
 
@@ -22,38 +22,44 @@ def shape_context_descriptor(icon_contour: np.ndarray,
       float: the shape context distance between the two contours.
   """
   extractor = cv2.createShapeContextDistanceExtractor()
-  return extractor.computeDistance(icon_contour, img_contour)
+  return extractor.computeDistance(icon_contour, image_contour)
 
 
-def detect_contours(image: np.ndarray,
-                    use_bilateral_filter: bool) -> List[List[List[int]]]:
+def detect_contours(
+    image: np.ndarray,
+    use_bilateral_filter: bool,
+    find_contour_approx: int = cv2.CHAIN_APPROX_NONE) -> List[List[List[int]]]:
   """Detects the contours in the image.
 
   Arguments:
       image: Input image, as ndarray.
       use_bilateral_filter: whether to use bilateral filter
        to smooth out edges before Canny edge detection.
+      find_contour_approx: the mode taken in by findContours
+       regarding approximating contours. The default is no approximation;
+       other options include cv2.CHAIN_APPROX_SIMPLE
+        and CHAIN_APPROX_TC89_L1 or CHAIN_APPROX_TC89_KCOS
 
   Returns:
       List of contour groups,each of which is a list of points.
   """
-  imgray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+  image_gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
   if use_bilateral_filter:
-    imgray = cv2.bilateralFilter(imgray, 5, 20, 50)
-  edges = cv2.Canny(imgray, 10, 25)
-  img_contours, _ = cv2.findContours(edges, cv2.RETR_TREE,
-                                     cv2.CHAIN_APPROX_NONE)
-  return img_contours
+    image_gray = cv2.bilateralFilter(image_gray, 5, 20, 50)
+  edges = cv2.Canny(image_gray, 10, 25)
+  image_contours, _ = cv2.findContours(edges, cv2.RETR_TREE,
+                                       find_contour_approx)
+  return image_contours
 
 
 def cluster_contours_dbscan(
-    img_contours: np.ndarray,
+    image_contours: np.ndarray,
     eps: float = 10,
     min_samples: int = 5) -> Tuple[List[np.ndarray], List[np.ndarray]]:
   """Group contours using DBSCAN.
 
   Arguments:
-      img_contours: Flattened list of all points in all contours of an image.
+      image_contours: Flattened list of all points in all contours of an image.
       That is: List[List[int]]
       eps: The maximum distance a point can be away to be considered
        within neighborhood of another point. (default: {10})
@@ -61,13 +67,14 @@ def cluster_contours_dbscan(
        of a point for it to be a core point. (default: {5})
 
   Returns:
-      List of groups of points, each representing its own contour,
-       and a masked list of groups of bool values, each representing
-        which points are core points or not. The contours and masks
-        are np.ndarrays of roughly List[List[int]] and List[bool].
+      Tuple: (List of groups of points each representing its own contour,
+       List of corresponding boolean mask of core points).
+       The contours and masks are np.ndarrays of List[List[int]]
+       and List[bool].
   """
-  clusters = sklearn.cluster.DBSCAN(eps=eps,
-                                    min_samples=min_samples).fit(img_contours)
+  clusters = sklearn.cluster.DBSCAN(
+      eps=eps, min_samples=min_samples).fit(image_contours)
+  # a label of -1 means the point was not clustered by DBSCAN - a "noise" point
   n_clusters = len(set(
       clusters.labels_)) - (1 if -1 in clusters.labels_ else 0)
   n_noise = list(clusters.labels_).count(-1)
@@ -78,7 +85,7 @@ def cluster_contours_dbscan(
   contour_groups = []
   core_samples_mask_groups = []
   for i in range(0, n_clusters):
-    contour_group = img_contours[np.argwhere(clusters.labels_ == i)]
+    contour_group = image_contours[np.argwhere(clusters.labels_ == i)]
     contour_groups.append(np.vstack(contour_group).squeeze())
     core_samples_mask_groups.append(
         np.vstack(
@@ -86,11 +93,11 @@ def cluster_contours_dbscan(
   return contour_groups, core_samples_mask_groups
 
 
-def get_nms_bounding_boxes(
+def suppress_overlapping_bounding_boxes(
     contours: np.ndarray,
     confidences: np.ndarray,
     confidence_threshold: float,
-    nms_threshold: float = 0.9,
+    iou_threshold: float = 0.9,
 ) -> List[BoundingBox]:
   """Returns bounding boxes after filtering through non-max suppression.
 
@@ -99,7 +106,7 @@ def get_nms_bounding_boxes(
       confidences: confidence scores associated with each contour.
       confidence_threshold: only keep bboxes with
        confidence scores (strictly) above this threshold.
-      nms_threshold: two bboxes with an IOU >=
+      iou_threshold: two bboxes with an IOU >=
        this threshold are considered the same bbox. (default: 0.9)
 
   Returns:
@@ -109,12 +116,10 @@ def get_nms_bounding_boxes(
   rects = []
   for contour in contours:
     contours_poly = cv2.approxPolyDP(contour, 3, True)
-    bound_rect = cv2.boundingRect(contours_poly)
-    rects.append(bound_rect)
-    bbox = BoundingBox(bound_rect[0], bound_rect[1],
-                       bound_rect[0] + bound_rect[2],
-                       bound_rect[1] + bound_rect[3])
+    x, y, w, h = cv2.boundingRect(contours_poly)
+    rects.append([x, y, w, h])
+    bbox = BoundingBox(x, y, x + w, y + h)
     bboxes.append(bbox)
   indices = cv2.dnn.NMSBoxes(rects, confidences, confidence_threshold,
-                             nms_threshold)
+                             iou_threshold)
   return [bboxes[i[0]] for i in indices]

--- a/modules/benchmark_pipeline.py
+++ b/modules/benchmark_pipeline.py
@@ -111,11 +111,12 @@ class BenchmarkPipeline:
     """
     for i, image_bgr in enumerate(self.image_list):
       box_list = boxes[i]
+      im_bgr_copy = image_bgr.copy()
       for box in box_list:
         # top left and bottom right corner of rectangle
-        cv2.rectangle(image_bgr, (box.min_x, box.min_y),
+        cv2.rectangle(im_bgr_copy, (box.min_x, box.min_y),
                       (box.max_x, box.max_y), (0, 255, 0), 3)
-      image_rgb = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB)
+      image_rgb = cv2.cvtColor(im_bgr_copy, cv2.COLOR_BGR2RGB)
 
       if image_rgb is None:
         print("Could not read the image.")

--- a/modules/benchmark_pipeline.py
+++ b/modules/benchmark_pipeline.py
@@ -111,12 +111,12 @@ class BenchmarkPipeline:
     """
     for i, image_bgr in enumerate(self.image_list):
       box_list = boxes[i]
-      im_bgr_copy = image_bgr.copy()
+      image_bgr_copy = image_bgr.copy()
       for box in box_list:
         # top left and bottom right corner of rectangle
-        cv2.rectangle(im_bgr_copy, (box.min_x, box.min_y),
+        cv2.rectangle(image_bgr_copy, (box.min_x, box.min_y),
                       (box.max_x, box.max_y), (0, 255, 0), 3)
-      image_rgb = cv2.cvtColor(im_bgr_copy, cv2.COLOR_BGR2RGB)
+      image_rgb = cv2.cvtColor(image_bgr_copy, cv2.COLOR_BGR2RGB)
 
       if image_rgb is None:
         print("Could not read the image.")

--- a/modules/benchmark_pipeline.py
+++ b/modules/benchmark_pipeline.py
@@ -7,6 +7,7 @@ import cv2
 import matplotlib.pyplot
 from modules import defaults
 from modules import icon_finder_random
+from modules import icon_finder_shape_context
 from modules import util
 from modules.bounding_box import BoundingBox
 import numpy as np
@@ -21,7 +22,10 @@ _IMAGE_FEATURE_DESCRIPTION = {
     "box_xmax": tf.io.FixedLenFeature([], tf.float32),
 }
 
-_ICON_FINDERS = {"random": icon_finder_random.IconFinderRandom}  # pytype: disable=module-attr
+_ICON_FINDERS = {
+    "random": icon_finder_random.IconFinderRandom,
+    "shape-context": icon_finder_shape_context.IconFinderShapeContext
+}  # pytype: disable=module-attr
 
 
 def _parse_image_function(
@@ -141,6 +145,7 @@ class BenchmarkPipeline:
       self.proposed_boxes.append(icon_finder.find_icons(image, icon))
       timer.stop()
       times.append(timer.calculate_info(output_path))
+    print("Average time per image: %f" % np.mean(times))
     return np.mean(times)
 
   def calculate_memory(self, icon_finder, output_path: str) -> float:
@@ -164,6 +169,7 @@ class BenchmarkPipeline:
       memtracker = util.MemoryTracker()  # pytype: disable=module-attr
       memtracker.run_and_track_memory((icon_finder.find_icons, (image, icon)))
       mems.append(memtracker.calculate_info(output_path))
+    print("Average MiBs per image: %f" % np.mean(mems))
     return np.mean(mems)
 
   def find_icons(

--- a/modules/bounding_box.py
+++ b/modules/bounding_box.py
@@ -9,16 +9,16 @@ class BoundingBox:
    Assumes each coordinate corresponds to a pixel, and
     therefore is zero-indexed.
   """
-  min_x: float
-  min_y: float
-  max_x: float
-  max_y: float
+  min_x: int
+  min_y: int
+  max_x: int
+  max_y: int
 
   def __init__(self, min_x: float, min_y: float, max_x: float, max_y: float):
-    self.min_x = min_x
-    self.min_y = min_y
-    self.max_x = max_x
-    self.max_y = max_y
+    self.min_x = int(min_x)
+    self.min_y = int(min_y)
+    self.max_x = int(max_x)
+    self.max_y = int(max_y)
 
   def calculate_area(self) -> float:
     # add one in calculations because pixel numbers are 0-indexed

--- a/modules/defaults.py
+++ b/modules/defaults.py
@@ -4,6 +4,6 @@ This is where default configurations should be set
 and updated.
 """
 IOU_THRESHOLD = 0.6
-TFRECORD_PATH = "benchmark.tfrecord"
-FIND_ICON_OPTION = "random"
+TFRECORD_PATH = "benchmark_single_instance.tfrecord"
+FIND_ICON_OPTION = "shape-context"
 OUTPUT_PATH = ""

--- a/modules/icon_finder_shape_context.py
+++ b/modules/icon_finder_shape_context.py
@@ -69,6 +69,8 @@ class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable
       downsampled_icon_contour = icon_contour
 
     for image_contour_cluster in image_contours_clusters:
+      # expand the 1st dimension so that the shape is (n, 1, 2),
+      # which is what shape context algorithm wants
       icon_contour_3d = np.expand_dims(downsampled_icon_contour,
                                        axis=1)
       if image_contour_cluster.shape[0] > self.sc_max_num_points:
@@ -78,6 +80,8 @@ class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable
                              replace=False), :]
       else:
         downsampled_image_contour = image_contour_cluster
+      # expand the 1st dimension so that the shape is (n, 1, 2),
+      # which is what shape context algorithm wants
       image_contour_3d = np.expand_dims(downsampled_image_contour,
                                         axis=1)
       try:
@@ -117,7 +121,8 @@ class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable
     sorted_distances = nearby_distances[sorted_indices]
     print("Minimum distance achieved: %f" % sorted_distances[0])
     # invert distances since we want confidence scores
+    bboxes, rects = algorithms.get_bounding_boxes_from_contours(sorted_contours)
     bboxes = algorithms.suppress_overlapping_bounding_boxes(
-        sorted_contours, 1 / sorted_distances, 1 / self.sc_distance_threshold,
+        bboxes, rects, 1 / sorted_distances, 1 / self.sc_distance_threshold,
         self.nms_iou_threshold)
     return bboxes

--- a/modules/icon_finder_shape_context.py
+++ b/modules/icon_finder_shape_context.py
@@ -1,6 +1,6 @@
 """This module has an IconFinderShapeContext class for finding bounding boxes.
 """
-from typing import List
+from typing import List, Tuple
 
 import cv2
 
@@ -26,18 +26,20 @@ class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable
     self.nms_threshold = nms_threshold
 
   def _get_min_distance_contours(
-      self, icon_contour: List[List[int]],
-      img_contours_clusters: List[List[List[int]]]) -> List[List[int]]:
-    """Helper function to find the image contour closest to the icon.
+      self, icon_contour: np.ndarray,
+      img_contours_clusters: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Helper function to find the image contours closest to the icon.
 
     Arguments:
-        icon_contour: List of points representing the icon's contour.
-        img_contours_clusters: List of lists of points representing
-         each of the image's contour clusters.
+        icon_contour: List of points [x, y] representing the icon's contour.
+        More precisely, the type is: List[List[int]]
+        img_contours_clusters: List of lists of points [x, y] representing
+         each of the image's contour clusters. List[List[List[int]]]
 
     Returns:
-        List of points (x,y) representing the contour with the
-         minimal distance from the icon.
+        List of contours that are below the distance threshold
+        away from the icon: List[List[int]];
+        List of distances corresponding to each contour: List[float]
     """
 
     min_distance_contours = []

--- a/modules/icon_finder_shape_context.py
+++ b/modules/icon_finder_shape_context.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 
 import cv2
 
-from modules import algo_util
+from modules import algorithms
 from modules.bounding_box import BoundingBox
 import modules.icon_finder
 import numpy as np
@@ -18,62 +18,79 @@ class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable
                dbscan_min_neighbors: int = 5,
                sc_max_num_points: int = 100,
                sc_distance_threshold: float = 0.3,
-               nms_threshold: float = 0.9):
+               nms_iou_threshold: float = 0.9):
+    """Initializes the hyperparameters for the shape context icon finder.
+
+    Arguments:
+        dbscan_eps: The maximum distance a point can be away to be considered
+         within neighborhood of another point by DBSCAN. (default: {10})
+        dbscan_min_neighbors: The number of points needed within a neighborhood
+         of a point for it to be a core point by DBSCAN. (default: {5})
+        sc_max_num_points: The maximum number of points per image patch passed
+         into shape context descriptor algorithm; can vary slightly for icon
+         (default: {100})
+        sc_distance_threshold: The maximum shape context distance between an
+         icon and an image patch for the image patch to be under consideration
+         (default: {0.3})
+        nms_iou_threshold: The maximum IOU between two preliminary bounding
+         boxes of image patches before the lower confidence one is discarded by
+         non-max-suppression algorithm (default: {0.9})
+    """
     self.dbscan_eps = dbscan_eps
     self.dbscan_min_neighbors = dbscan_min_neighbors
     self.sc_max_num_points = sc_max_num_points
     self.sc_distance_threshold = sc_distance_threshold
-    self.nms_threshold = nms_threshold
+    self.nms_iou_threshold = nms_iou_threshold
 
-  def _get_min_distance_contours(
+  def _get_nearby_contours_and_distances(
       self, icon_contour: np.ndarray,
-      img_contours_clusters: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+      image_contours_clusters: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     """Helper function to find the image contours closest to the icon.
 
     Arguments:
         icon_contour: List of points [x, y] representing the icon's contour.
         More precisely, the type is: List[List[int]]
-        img_contours_clusters: List of lists of points [x, y] representing
+        image_contours_clusters: List of lists of points [x, y] representing
          each of the image's contour clusters. List[List[List[int]]]
 
     Returns:
-        List of contours that are below the distance threshold
-        away from the icon: List[List[int]];
-        List of distances corresponding to each contour: List[float]
+        Tuple: (List of contours that are below the distance threshold
+        away from the icon: List[List[int]], List of distances corresponding
+        to each contour: List[float])
     """
 
-    min_distance_contours = []
-    min_distances = []
+    nearby_contours = []
+    nearby_distances = []
 
-    if len(icon_contour) > self.sc_max_num_points:
+    if icon_contour.shape[0] > self.sc_max_num_points:
       downsampled_icon_contour = icon_contour[np.random.choice(
-          icon_contour.shape[0], len(icon_contour) // 2, replace=False), :]
+          icon_contour.shape[0], icon_contour.shape[0] // 2, replace=False), :]
     else:
       downsampled_icon_contour = icon_contour
 
-    for img_contour_cluster in img_contours_clusters:
-      icon_contour_3d = np.expand_dims(np.array(downsampled_icon_contour),
+    for image_contour_cluster in image_contours_clusters:
+      icon_contour_3d = np.expand_dims(downsampled_icon_contour,
                                        axis=1)
-      if len(img_contour_cluster) > self.sc_max_num_points:
-        downsampled_image_contour = img_contour_cluster[
-            np.random.choice(img_contour_cluster.shape[0],
+      if image_contour_cluster.shape[0] > self.sc_max_num_points:
+        downsampled_image_contour = image_contour_cluster[
+            np.random.choice(image_contour_cluster.shape[0],
                              self.sc_max_num_points,
                              replace=False), :]
       else:
-        downsampled_image_contour = img_contour_cluster
-      image_contour_3d = np.expand_dims(np.array(downsampled_image_contour),
+        downsampled_image_contour = image_contour_cluster
+      image_contour_3d = np.expand_dims(downsampled_image_contour,
                                         axis=1)
       try:
-        distance = algo_util.shape_context_descriptor(icon_contour_3d,
-                                                      image_contour_3d)
+        distance = algorithms.shape_context_distance(icon_contour_3d,
+                                                     image_contour_3d)
         if distance < self.sc_distance_threshold:
-          min_distance_contours.append(img_contour_cluster)
-          min_distances.append(distance)
+          nearby_contours.append(image_contour_cluster)
+          nearby_distances.append(distance)
       except cv2.error as e:
         print(e)
         print("These were the icon and image shapes: %s %s" %
               (str(icon_contour_3d.shape), str(image_contour_3d.shape)))
-    return np.array(min_distance_contours), np.array(min_distances)
+    return np.array(nearby_contours), np.array(nearby_distances)
 
   def find_icons(self, image: np.ndarray,
                  icon: np.ndarray) -> List[BoundingBox]:
@@ -87,18 +104,20 @@ class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable
         List[BoundingBox] -- Bounding Box for each instance of icon in image.
     """
 
-    img_contours = np.vstack(algo_util.detect_contours(image, True)).squeeze()
-    icon_contour = np.vstack(algo_util.detect_contours(icon, True)).squeeze()
-    img_contours_clusters, _ = algo_util.cluster_contours_dbscan(
-        img_contours, self.dbscan_eps, self.dbscan_min_neighbors)
+    image_contours = np.vstack(algorithms.detect_contours(image,
+                                                          True)).squeeze()
+    icon_contour = np.vstack(algorithms.detect_contours(icon, True)).squeeze()
+    image_contours_clusters, _ = algorithms.cluster_contours_dbscan(
+        image_contours, self.dbscan_eps, self.dbscan_min_neighbors)
 
-    min_distance_contours, min_distances = self._get_min_distance_contours(
-        icon_contour, img_contours_clusters)
-    sorted_contours = min_distance_contours[min_distances.argsort()]
-    sorted_distances = np.sort(min_distances)
+    nearby_contours, nearby_distances = self._get_nearby_contours_and_distances(
+        icon_contour, image_contours_clusters)
+    sorted_indices = nearby_distances.argsort()
+    sorted_contours = nearby_contours[sorted_indices]
+    sorted_distances = nearby_distances[sorted_indices]
     print("Minimum distance achieved: %f" % sorted_distances[0])
     # invert distances since we want confidence scores
-    bboxes = algo_util.get_nms_bounding_boxes(
-        sorted_contours, 1 / sorted_distances,
-        1 / self.sc_distance_threshold, self.nms_threshold)
+    bboxes = algorithms.suppress_overlapping_bounding_boxes(
+        sorted_contours, 1 / sorted_distances, 1 / self.sc_distance_threshold,
+        self.nms_iou_threshold)
     return bboxes

--- a/modules/icon_finder_shape_context.py
+++ b/modules/icon_finder_shape_context.py
@@ -1,0 +1,81 @@
+"""This module has an IconFinderRandom class for randomly finding bounding boxes.
+"""
+from typing import List
+
+import cv2
+
+from modules import algo_util
+from modules.bounding_box import BoundingBox
+import modules.icon_finder
+import numpy as np
+
+
+class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable=module-attr
+  """This class generates bounding boxes via Shape Context Descriptors."""
+
+  def _get_min_distance_contour(
+      self, icon_contour: List[List[int]],
+      img_contours_clusters: List[List[List[int]]]) -> List[List[int]]:
+    """Helper function to find the image contour closest to the icon.
+
+    Arguments:
+        icon_contour: List of points representing the icon's contour.
+        img_contours_clusters: List of groups of points representing
+         each of the image's contour clusters.
+
+    Returns:
+        List of points (x,y) representing the contour with the
+         minimal distance from the icon.
+    """
+    min_distance = 10000
+    min_distance_contour = None
+    max_num_points = 100
+    if len(icon_contour) > max_num_points:
+      downsampled_icon_contour = icon_contour[np.random.choice(
+          icon_contour.shape[0], len(icon_contour) // 2, replace=False), :]
+    else:
+      downsampled_icon_contour = icon_contour
+
+    for img_contour_cluster in img_contours_clusters:
+      icon_contour_3d = np.array(
+          [downsampled_icon_contour, downsampled_icon_contour])
+      if len(img_contour_cluster) > max_num_points:
+        downsampled_image_contour = img_contour_cluster[np.random.choice(
+            img_contour_cluster.shape[0], max_num_points, replace=False), :]
+      else:
+        downsampled_image_contour = img_contour_cluster
+      image_contour_3d = np.array(
+          [downsampled_image_contour, downsampled_image_contour])
+      distance = algo_util.shape_context_descriptor(icon_contour_3d,
+                                                    image_contour_3d)
+      print(distance)
+      if distance < min_distance:
+        min_distance = distance
+        min_distance_contour = img_contour_cluster
+    return min_distance_contour
+
+  def find_icons(self, image: np.ndarray,
+                 icon: np.ndarray) -> List[BoundingBox]:
+    """Find instances of icon in a given image via shape context descriptor.
+
+    Arguments:
+        image: Numpy array representing image
+        icon: Numpy array representing icon
+
+    Returns:
+        List[BoundingBox] -- Bounding Box for each instance of icon in image.
+    """
+
+    img_contours = np.vstack(algo_util.detect_contours(image, True)).squeeze()
+    icon_contour = np.vstack(algo_util.detect_contours(icon, True)).squeeze()
+    img_contours_clusters, _ = algo_util.cluster_contours_dbscan(img_contours)
+
+    min_distance_contour = self._get_min_distance_contour(
+        icon_contour, img_contours_clusters)
+
+    contours_poly = cv2.approxPolyDP(min_distance_contour, 3, True)
+    bound_rect = cv2.boundingRect(contours_poly)
+    bbox = BoundingBox(bound_rect[0], bound_rect[1],
+                       bound_rect[0] + bound_rect[2],
+                       bound_rect[1] + bound_rect[3])
+    return [bbox]

--- a/modules/icon_finder_shape_context.py
+++ b/modules/icon_finder_shape_context.py
@@ -1,4 +1,4 @@
-"""This module has an IconFinderRandom class for randomly finding bounding boxes.
+"""This module has an IconFinderShapeContext class for finding bounding boxes.
 """
 from typing import List
 
@@ -13,46 +13,65 @@ import numpy as np
 class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable=module-attr
   """This class generates bounding boxes via Shape Context Descriptors."""
 
-  def _get_min_distance_contour(
+  def __init__(self,
+               dbscan_eps: float = 10,
+               dbscan_min_neighbors: int = 5,
+               sc_max_num_points: int = 100,
+               sc_distance_threshold: float = 0.3,
+               nms_threshold: float = 0.9):
+    self.dbscan_eps = dbscan_eps
+    self.dbscan_min_neighbors = dbscan_min_neighbors
+    self.sc_max_num_points = sc_max_num_points
+    self.sc_distance_threshold = sc_distance_threshold
+    self.nms_threshold = nms_threshold
+
+  def _get_min_distance_contours(
       self, icon_contour: List[List[int]],
       img_contours_clusters: List[List[List[int]]]) -> List[List[int]]:
     """Helper function to find the image contour closest to the icon.
 
     Arguments:
         icon_contour: List of points representing the icon's contour.
-        img_contours_clusters: List of groups of points representing
+        img_contours_clusters: List of lists of points representing
          each of the image's contour clusters.
 
     Returns:
         List of points (x,y) representing the contour with the
          minimal distance from the icon.
     """
-    min_distance = 10000
-    min_distance_contour = None
-    max_num_points = 100
-    if len(icon_contour) > max_num_points:
+
+    min_distance_contours = []
+    min_distances = []
+
+    if len(icon_contour) > self.sc_max_num_points:
       downsampled_icon_contour = icon_contour[np.random.choice(
           icon_contour.shape[0], len(icon_contour) // 2, replace=False), :]
     else:
       downsampled_icon_contour = icon_contour
 
     for img_contour_cluster in img_contours_clusters:
-      icon_contour_3d = np.array(
-          [downsampled_icon_contour, downsampled_icon_contour])
-      if len(img_contour_cluster) > max_num_points:
-        downsampled_image_contour = img_contour_cluster[np.random.choice(
-            img_contour_cluster.shape[0], max_num_points, replace=False), :]
+      icon_contour_3d = np.expand_dims(np.array(downsampled_icon_contour),
+                                       axis=1)
+      if len(img_contour_cluster) > self.sc_max_num_points:
+        downsampled_image_contour = img_contour_cluster[
+            np.random.choice(img_contour_cluster.shape[0],
+                             self.sc_max_num_points,
+                             replace=False), :]
       else:
         downsampled_image_contour = img_contour_cluster
-      image_contour_3d = np.array(
-          [downsampled_image_contour, downsampled_image_contour])
-      distance = algo_util.shape_context_descriptor(icon_contour_3d,
-                                                    image_contour_3d)
-      print(distance)
-      if distance < min_distance:
-        min_distance = distance
-        min_distance_contour = img_contour_cluster
-    return min_distance_contour
+      image_contour_3d = np.expand_dims(np.array(downsampled_image_contour),
+                                        axis=1)
+      try:
+        distance = algo_util.shape_context_descriptor(icon_contour_3d,
+                                                      image_contour_3d)
+        if distance < self.sc_distance_threshold:
+          min_distance_contours.append(img_contour_cluster)
+          min_distances.append(distance)
+      except cv2.error as e:
+        print(e)
+        print("These were the icon and image shapes: %s %s" %
+              (str(icon_contour_3d.shape), str(image_contour_3d.shape)))
+    return np.array(min_distance_contours), np.array(min_distances)
 
   def find_icons(self, image: np.ndarray,
                  icon: np.ndarray) -> List[BoundingBox]:
@@ -68,14 +87,16 @@ class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable
 
     img_contours = np.vstack(algo_util.detect_contours(image, True)).squeeze()
     icon_contour = np.vstack(algo_util.detect_contours(icon, True)).squeeze()
-    img_contours_clusters, _ = algo_util.cluster_contours_dbscan(img_contours)
+    img_contours_clusters, _ = algo_util.cluster_contours_dbscan(
+        img_contours, self.dbscan_eps, self.dbscan_min_neighbors)
 
-    min_distance_contour = self._get_min_distance_contour(
+    min_distance_contours, min_distances = self._get_min_distance_contours(
         icon_contour, img_contours_clusters)
-
-    contours_poly = cv2.approxPolyDP(min_distance_contour, 3, True)
-    bound_rect = cv2.boundingRect(contours_poly)
-    bbox = BoundingBox(bound_rect[0], bound_rect[1],
-                       bound_rect[0] + bound_rect[2],
-                       bound_rect[1] + bound_rect[3])
-    return [bbox]
+    sorted_contours = min_distance_contours[min_distances.argsort()]
+    sorted_distances = np.sort(min_distances)
+    print("Minimum distance achieved: %f" % sorted_distances[0])
+    # invert distances since we want confidence scores
+    bboxes = algo_util.get_nms_bounding_boxes(
+        sorted_contours, 1 / sorted_distances,
+        1 / self.sc_distance_threshold, self.nms_threshold)
+    return bboxes

--- a/modules/util.py
+++ b/modules/util.py
@@ -26,7 +26,7 @@ class LatencyTimer:
   def stop(self):
     self.pr.disable()
 
-  def calculate_info(self, output_path=defaults.OUTPUT_PATH):
+  def calculate_info(self, output_path: str = defaults.OUTPUT_PATH) -> float:
     """Calculates latency info and optionally prints to file.
 
     Args:
@@ -69,7 +69,7 @@ class MemoryTracker:
     """
     self.memory_info = memory_profiler.memory_usage(func_args_tuple)
 
-  def calculate_info(self, output_path=defaults.OUTPUT_PATH):
+  def calculate_info(self, output_path: str = defaults.OUTPUT_PATH) -> float:
     """Calculates memory usage info and optionally prints to file.
 
     Args:

--- a/modules/util.py
+++ b/modules/util.py
@@ -44,7 +44,6 @@ class LatencyTimer:
     if output_path:
       with open(output_path, "a") as output_file:
         output_file.write(info)
-    print(info)
     # parse cProfiler's output to get the total time as a float
     first_line = info.partition("\n")[0]
     total_time = first_line.split(" ")[-2]
@@ -86,5 +85,4 @@ class MemoryTracker:
     if output_path:
       with open(output_path, "a") as output_file:
         output_file.write(output_msg)
-    print(output_msg)
     return average_mb

--- a/modules/util.py
+++ b/modules/util.py
@@ -85,4 +85,4 @@ class MemoryTracker:
     if output_path:
       with open(output_path, "a") as output_file:
         output_file.write(output_msg)
-    return average_mb
+    return float(average_mb)

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ ipywidgets==7.5.1
 isort==4.3.21
 jedi==0.17.1
 Jinja2==2.11.2
+joblib==0.16.0
 jsonschema==3.2.0
 jupyter==1.0.0
 jupyter-client==6.1.3
@@ -52,8 +53,7 @@ nose==1.3.7
 notebook==6.0.3
 numpy==1.18.5
 oauthlib==3.1.0
-opencv-contrib-python==4.2.0.34
-opencv-python==4.2.0.34
+opencv-contrib-python==4.3.0.36
 opt-einsum==3.2.1
 packaging==20.4
 pandas==1.0.5
@@ -86,11 +86,14 @@ qtconsole==4.7.4
 QtPy==1.9.0
 requests==2.24.0
 requests-oauthlib==1.3.0
+rope==0.17.0
 rsa==4.6
 scikit-image==0.17.2
+scikit-learn==0.23.1
 scipy==1.4.1
 Send2Trash==1.5.0
 six==1.15.0
+sklearn==0.0
 sympy==1.6
 tensorboard==2.2.2
 tensorboard-plugin-wit==1.6.0.post3
@@ -99,6 +102,7 @@ tensorflow-estimator==2.2.0
 termcolor==1.1.0
 terminado==0.8.3
 testpath==0.4.4
+threadpoolctl==2.1.0
 tifffile==2020.6.3
 toml==0.10.1
 tornado==6.0.4

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1,4 +1,4 @@
-from modules import algo_util
+from modules import algorithms
 import modules.benchmark_pipeline
 from modules.bounding_box import BoundingBox
 import numpy as np
@@ -23,12 +23,12 @@ def test_iou(box_1, box_2, expected):
   assert box_1.calculate_iou(box_2) == expected
 
 
-icon_contour_1 = np.array([[0, 0], [0, 4], [4, 0], [4, 4]])
-icon_contour_2 = np.array([[0, 0], [0, 7], [7, 0], [7, 7]])
-icon_contour_3 = np.array([[0, 0], [0, 6], [4, 0], [4, 6]])
-icon_contour_1_3d = np.expand_dims(icon_contour_1, axis=1)
-icon_contour_2_3d = np.expand_dims(icon_contour_2, axis=1)
-icon_contour_3_3d = np.expand_dims(icon_contour_3, axis=1)
+_ICON_CONTOUR_1 = np.array([[0, 0], [0, 4], [4, 0], [4, 4]])
+_ICON_CONTOUR_2 = np.array([[0, 0], [0, 7], [7, 0], [7, 7]])
+_ICON_CONTOUR_3 = np.array([[0, 0], [0, 6], [4, 0], [4, 6]])
+icon_contour_1_3d = np.expand_dims(_ICON_CONTOUR_1, axis=1)
+icon_contour_2_3d = np.expand_dims(_ICON_CONTOUR_2, axis=1)
+icon_contour_3_3d = np.expand_dims(_ICON_CONTOUR_3, axis=1)
 
 # covers: same shape against itself, expected distance ~0
 # (comparison across shapes yields Matrix Operand Error)
@@ -41,12 +41,12 @@ shape_context_tests = [
 
 @pytest.mark.parametrize("icon_1,icon_2,expected", shape_context_tests)
 def test_shape_context(icon_1, icon_2, expected):
-  assert algo_util.shape_context_descriptor(icon_1, icon_2) <= expected
+  assert algorithms.shape_context_distance(icon_1, icon_2) <= expected
 
 
 icon_contour_4 = np.array([[0, 0], [0, 10], [10, 0], [10, 10]])
 icon_contour_5 = np.array([[0, 0], [0, 10], [9, 0], [9, 10]])
-contour_list_1 = [icon_contour_1, icon_contour_2, icon_contour_3]
+contour_list_1 = [_ICON_CONTOUR_1, _ICON_CONTOUR_2, _ICON_CONTOUR_3]
 contour_list_2 = [icon_contour_4, icon_contour_5]
 confidence_1 = [5, 6, 7]
 confidence_2 = [5, 4]
@@ -67,9 +67,9 @@ nms_tests = [
 def test_get_nms_bounding_boxes(contours, confidences, confidence_threshold,
                                 nms_threshold, expected):
   assert len(
-      algo_util.get_nms_bounding_boxes(contours, confidences,
-                                       confidence_threshold,
-                                       nms_threshold)) == expected
+      algorithms.suppress_overlapping_bounding_boxes(contours, confidences,
+                                                    confidence_threshold,
+                                                    nms_threshold)) == expected
 
 
 def test_benchmark():

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -23,12 +23,12 @@ def test_iou(box_1, box_2, expected):
   assert box_1.calculate_iou(box_2) == expected
 
 
-_ICON_CONTOUR_1 = np.array([[0, 0], [0, 4], [4, 0], [4, 4]])
-_ICON_CONTOUR_2 = np.array([[0, 0], [0, 7], [7, 0], [7, 7]])
-_ICON_CONTOUR_3 = np.array([[0, 0], [0, 6], [4, 0], [4, 6]])
-icon_contour_1_3d = np.expand_dims(_ICON_CONTOUR_1, axis=1)
-icon_contour_2_3d = np.expand_dims(_ICON_CONTOUR_2, axis=1)
-icon_contour_3_3d = np.expand_dims(_ICON_CONTOUR_3, axis=1)
+icon_contour_1 = np.array([[0, 0], [0, 4], [4, 0], [4, 4]])
+icon_contour_2 = np.array([[0, 0], [0, 7], [7, 0], [7, 7]])
+icon_contour_3 = np.array([[0, 0], [0, 6], [4, 0], [4, 6]])
+icon_contour_1_3d = np.expand_dims(icon_contour_1, axis=1)
+icon_contour_2_3d = np.expand_dims(icon_contour_2, axis=1)
+icon_contour_3_3d = np.expand_dims(icon_contour_3, axis=1)
 
 # covers: same shape against itself, expected distance ~0
 # (comparison across shapes yields Matrix Operand Error)
@@ -44,32 +44,42 @@ def test_shape_context(icon_1, icon_2, expected):
   assert algorithms.shape_context_distance(icon_1, icon_2) <= expected
 
 
-icon_contour_4 = np.array([[0, 0], [0, 10], [10, 0], [10, 10]])
-icon_contour_5 = np.array([[0, 0], [0, 10], [9, 0], [9, 10]])
-contour_list_1 = [_ICON_CONTOUR_1, _ICON_CONTOUR_2, _ICON_CONTOUR_3]
-contour_list_2 = [icon_contour_4, icon_contour_5]
+icon_bbox_1 = BoundingBox(0, 0, 4, 4)
+icon_bbox_2 = BoundingBox(0, 0, 7, 7)
+icon_bbox_3 = BoundingBox(0, 0, 4, 6)
+icon_bbox_4 = BoundingBox(0, 0, 10, 10)
+icon_bbox_5 = BoundingBox(0, 0, 9, 10)
+icon_rect_1 = [0, 0, 4, 4]
+icon_rect_2 = [0, 0, 7, 7]
+icon_rect_3 = [0, 0, 4, 6]
+icon_rect_4 = [0, 0, 10, 10]
+icon_rect_5 = [0, 0, 9, 10]
+icon_bbox_list_1 = [icon_bbox_1, icon_bbox_2, icon_bbox_3]
+icon_bbox_list_2 = [icon_bbox_4, icon_bbox_5]
+icon_rect_list_1 = [icon_rect_1, icon_rect_2, icon_rect_3]
+icon_rect_list_2 = [icon_rect_4, icon_rect_5]
 confidence_1 = [5, 6, 7]
 confidence_2 = [5, 4]
 
 # contour list 1: tests varying confidence thresholds given IOUs < nms_threshold
-# contour list 2: tests varying confidence thresholds given IOU >= nms_threshold
+# contour list 2: tests varying confidence thresholds given IOU > nms_threshold
 nms_tests = [
-    (contour_list_1, confidence_1, 2, 0.9, 3),
-    (contour_list_1, confidence_1, 6, 0.9, 1),
-    (contour_list_2, confidence_2, 3, 0.9, 1),
-    (contour_list_2, confidence_2, 6, 0.9, 0),
+    (icon_bbox_list_1, icon_rect_list_1, confidence_1, 2, 0.9, 3),
+    (icon_bbox_list_1, icon_rect_list_1, confidence_1, 6, 0.9, 1),
+    (icon_bbox_list_2, icon_rect_list_2, confidence_2, 3, 0.89, 1),
+    (icon_bbox_list_2, icon_rect_list_2, confidence_2, 6, 0.9, 0),
 ]
 
 
 @pytest.mark.parametrize(
-    "contours,confidences,confidence_threshold,nms_threshold,expected",
+    "bboxes,rects,confidences,confidence_threshold,nms_threshold,expected",
     nms_tests)
-def test_get_nms_bounding_boxes(contours, confidences, confidence_threshold,
-                                nms_threshold, expected):
+def test_get_nms_bounding_boxes(bboxes, rects, confidences,
+                                confidence_threshold, nms_threshold, expected):
   assert len(
-      algorithms.suppress_overlapping_bounding_boxes(contours, confidences,
-                                                    confidence_threshold,
-                                                    nms_threshold)) == expected
+      algorithms.suppress_overlapping_bounding_boxes(
+          bboxes, rects, confidences, confidence_threshold,
+          nms_threshold)) == expected
 
 
 def test_benchmark():

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1,5 +1,7 @@
+from modules import algo_util
 import modules.benchmark_pipeline
 from modules.bounding_box import BoundingBox
+import numpy as np
 import pytest
 
 box_a = BoundingBox(20, 20, 29, 29)
@@ -19,6 +21,26 @@ bounding_box_tests = [(box_a, box_b, 25 / 700), (box_a, box_c, 0),
 @pytest.mark.parametrize("box_1,box_2,expected", bounding_box_tests)
 def test_iou(box_1, box_2, expected):
   assert box_1.calculate_iou(box_2) == expected
+
+
+icon_contour_1 = [[0, 0], [0, 4], [4, 0], [4, 4]]
+icon_contour_2 = [[0, 0], [0, 6], [6, 0], [6, 6]]
+icon_contour_3 = [[0, 0], [0, 6], [4, 0], [4, 6]]
+icon_contour_1_3d = np.array([icon_contour_1, icon_contour_1])
+icon_contour_2_3d = np.array([icon_contour_2, icon_contour_2])
+icon_contour_3_3d = np.array([icon_contour_3, icon_contour_3])
+# covers: same square, different size square, square vs rectangle
+# all should have ~0 distance
+shape_context_tests = [
+    (icon_contour_1_3d, icon_contour_2_3d, 1e-15),
+    (icon_contour_1_3d, icon_contour_1_3d, 1e-15),
+    (icon_contour_1_3d, icon_contour_3_3d, 1e-15),
+]
+
+
+@pytest.mark.parametrize("icon_1,icon_2,expected", shape_context_tests)
+def test_shape_context(icon_1, icon_2, expected):
+  assert algo_util.shape_context_descriptor(icon_1, icon_2) <= expected
 
 
 def test_benchmark():


### PR DESCRIPTION
Baseline implementation of shape context descriptor:

- Integrates contour finding, clustering with DBSCAN, shape context descriptor, and non-max suppression into one find_icon algorithm/model (titled "shape-context" option) that can be selected by the benchmark-pipeline to benchmark with. 
- Current stats are run on benchmark-single-instance.tfrecord, a dataset of 30 images. We get roughly 0.6 accuracy (varies a little because of random downsampling), for an average of 3 seconds per image, and ~600 MiBs of memory used. This is essentially the baseline that we will be iterating on! (And this is tested as part of CI tests.)
- A note on shape context descriptor: the computeDistance function from openCV will give a "matrix operand error" for some inputs (unknown reason, could be an [OpenCV bug](https://github.com/opencv/opencv/issues/5076)), which happens 3 times out of the ~1200 times we call the distance function. This error was only seen after our input format changed from a numpy array of shape (2, n, 2) where the point set was essentially doubled to (n, 1, 2), where the original pointset was kept but the column-dimension was expanded. 

Style and Continuous Integration tests:
- gpylint passes locally (we're not able to get this as part of our CI test suite)
- Continuous integration tests also pass with the pytype modification of ignoring import-errors as from the previous PR.
- Test cases mostly rely on the benchmark pipeline integration test, which calls all the functions and openCV libraries that were added, though the shape context descriptor and non-max suppression utilities are also singled out as unit tests; the former because of the lack of documentation from OpenCV on how to use it properly; and the later because of an added workflow. 

