### PR TITLE
Support for Multiple Instances of an Icon in an Image

### DIFF
--- a/modules/benchmark_pipeline.py
+++ b/modules/benchmark_pipeline.py
@@ -9,6 +9,7 @@ from modules import defaults
 from modules import icon_finder_random
 from modules import util
 from modules.bounding_box import BoundingBox
+from modules.correctness_metrics import CorrectnessMetrics
 import numpy as np
 
 _ICON_FINDERS = {"random": icon_finder_random.IconFinderRandom}  # pytype: disable=module-attr
@@ -134,7 +135,7 @@ class BenchmarkPipeline:
       output_path: str = defaults.OUTPUT_PATH,
       find_icon_option: str = defaults.FIND_ICON_OPTION,
       multi_instance_icon: bool = False
-  ) -> Tuple[float, float, float, float, float]:
+  ) -> Tuple[CorrectnessMetrics, float, float]:
     """Integrated pipeline for testing calculated bounding boxes.
 
     Compares calculated bounding boxes to ground truth,
@@ -156,7 +157,7 @@ class BenchmarkPipeline:
           (default: {False})
 
     Returns:
-        Tuple(accuracy, precision, recall, avg runtime, avg memory of
+        Tuple(CorrectnessMetrics, avg runtime, avg memory of
          the bounding box detection process.)
     """
     avg_runtime_secs, avg_memory_mbs = self.find_icons(find_icon_option,
@@ -168,16 +169,16 @@ class BenchmarkPipeline:
           "images/" + find_icon_option + "/" + find_icon_option +
           "-visualized", self.proposed_boxes)
     if multi_instance_icon:
-      accuracy, precision, recall = util.evaluate_proposed_bounding_boxes(
+      correctness = util.evaluate_proposed_bounding_boxes(
           iou_threshold, self.proposed_boxes, self.gold_boxes, output_path)
     else:
-      accuracy, precision, recall = util.evaluate_proposed_bounding_boxes(
+      correctness = util.evaluate_proposed_bounding_boxes(
           iou_threshold,
           [[boxes[0]] for boxes in self.proposed_boxes],
           [[boxes[0]] for boxes in self.gold_boxes],
           output_path
       )
-    return accuracy, precision, recall, avg_runtime_secs, avg_memory_mbs
+    return correctness, avg_runtime_secs, avg_memory_mbs
 
 
 if __name__ == "__main__":

--- a/modules/benchmark_pipeline.py
+++ b/modules/benchmark_pipeline.py
@@ -1,7 +1,7 @@
 """BenchmarkPipeline class and tfRecord utility functions."""
 
 import argparse
-from typing import Any, List, Tuple
+from typing import List, Tuple
 
 import cv2
 import matplotlib.pyplot
@@ -10,85 +10,8 @@ from modules import icon_finder_random
 from modules import util
 from modules.bounding_box import BoundingBox
 import numpy as np
-import tensorflow as tf
-
-_IMAGE_FEATURE_DESCRIPTION = {
-    "encoded_image_png": tf.io.FixedLenFeature([], tf.string),
-    "encoded_icon_png": tf.io.FixedLenFeature([], tf.string),
-    "box_ymin": tf.io.FixedLenSequenceFeature([],
-                                              tf.float32,
-                                              allow_missing=True),
-    "box_xmin": tf.io.FixedLenSequenceFeature([],
-                                              tf.float32,
-                                              allow_missing=True),
-    "box_ymax": tf.io.FixedLenSequenceFeature([],
-                                              tf.float32,
-                                              allow_missing=True),
-    "box_xmax": tf.io.FixedLenSequenceFeature([],
-                                              tf.float32,
-                                              allow_missing=True),
-}
 
 _ICON_FINDERS = {"random": icon_finder_random.IconFinderRandom}  # pytype: disable=module-attr
-
-
-def _parse_image_function(
-    example_proto: tf.python.framework.ops.Tensor) -> Any:
-  return tf.io.parse_single_example(example_proto, _IMAGE_FEATURE_DESCRIPTION)
-
-
-def _parse_image_dataset(
-    path: str) -> tf.python.data.ops.dataset_ops.MapDataset:
-  raw_dataset = tf.data.TFRecordDataset(path)
-  parsed_image_dataset = raw_dataset.map(_parse_image_function)
-  return parsed_image_dataset
-
-
-def _parse_gold_boxes(
-    parsed_image_dataset: tf.python.data.ops.dataset_ops.MapDataset
-) -> List[List[BoundingBox]]:
-  """Retrieve a list of bounding boxes from dataset.
-
-  Arguments:
-      parsed_image_dataset: Original dataset read from TFRecord
-
-  Returns:
-      List of lists of ground truth BoundingBoxes.
-  """
-  all_images_gold_boxes = []
-  for image_features in parsed_image_dataset:
-    single_image_gold_boxes = []
-    for xmin, ymin, xmax, ymax in zip(image_features["box_xmin"],
-                                      image_features["box_ymin"],
-                                      image_features["box_xmax"],
-                                      image_features["box_ymax"]):
-      gold_box = BoundingBox(xmin, ymin, xmax, ymax)
-      single_image_gold_boxes.append(gold_box)
-    all_images_gold_boxes.append(single_image_gold_boxes)
-  return all_images_gold_boxes
-
-
-def _parse_images_and_icons(
-    parsed_image_dataset: tf.python.data.ops.dataset_ops.MapDataset
-) -> Tuple[List[np.ndarray], List[np.ndarray]]:
-  """Private function for parsing images and icons.
-
-  Arguments:
-      parsed_image_dataset: image dataset read from TFRecord
-
-  Returns:
-      (List of images, List of icons)
-  """
-  image_list = []
-  icon_list = []
-  for image_features in parsed_image_dataset:
-    image_raw = image_features["encoded_image_png"].numpy()
-    image_bgr = cv2.imdecode(np.frombuffer(image_raw, dtype=np.uint8), -1)
-    image_list.append(image_bgr)
-    icon_raw = image_features["encoded_icon_png"].numpy()
-    icon_bgr = cv2.imdecode(np.frombuffer(icon_raw, dtype=np.uint8), -1)
-    icon_list.append(icon_bgr)
-  return image_list, icon_list
 
 
 class BenchmarkPipeline:
@@ -100,9 +23,9 @@ class BenchmarkPipeline:
   """
 
   def __init__(self, tfrecord_path: str = defaults.TFRECORD_PATH):
-    parsed_image_dataset = _parse_image_dataset(tfrecord_path)
-    self.gold_boxes = _parse_gold_boxes(parsed_image_dataset)
-    self.image_list, self.icon_list = _parse_images_and_icons(
+    parsed_image_dataset = util.parse_image_dataset(tfrecord_path)
+    self.gold_boxes = util.parse_gold_boxes(parsed_image_dataset)
+    self.image_list, self.icon_list = util.parse_images_and_icons(
         parsed_image_dataset)
     self.proposed_boxes = []
 
@@ -204,39 +127,14 @@ class BenchmarkPipeline:
                                   output_path), self.calculate_memory(
                                       icon_finder, output_path)
 
-  def single_instance_eval(self, iou_threshold: float,
-                           output_path: str) -> float:
-    """Evaluates proposed bounding boxes with one instance of icon in image.
-
-    Arguments:
-        iou_threshold: Threshold above which a bbox is accurate
-        output_path: Output path of writing accuracy info
-
-    Returns:
-        float -- accuracy calculated
-    """
-    ious = []
-    for (proposed_box_list, gold_box_list) in zip(self.proposed_boxes,
-                                                  self.gold_boxes):
-      ious.append(proposed_box_list[0].calculate_iou(gold_box_list[0]))
-    accuracy = np.sum(np.array(ious) > iou_threshold) / len(ious)
-    if output_path:
-      with open(output_path, "a") as output_file:
-        output_file.write("Accuracy: %f\n" % accuracy)
-    print("Accuracy: %f\n" % accuracy)
-    return accuracy
-
-  def multi_instance_eval(self, iou_threshold: float,
-                          output_path: str) -> float:
-    raise NotImplementedError
-
   def evaluate(
       self,
       visualize: bool = False,
       iou_threshold: float = defaults.IOU_THRESHOLD,
       output_path: str = defaults.OUTPUT_PATH,
       find_icon_option: str = defaults.FIND_ICON_OPTION,
-      multi_instance_icon: bool = False) -> Tuple[float, float, float]:
+      multi_instance_icon: bool = False
+  ) -> Tuple[float, float, float, float, float]:
     """Integrated pipeline for testing calculated bounding boxes.
 
     Compares calculated bounding boxes to ground truth,
@@ -258,8 +156,8 @@ class BenchmarkPipeline:
           (default: {False})
 
     Returns:
-        float, float, float -- accuracy, avg runtime, avg memory of the bounding
-         box detection process.
+        Tuple(accuracy, precision, recall, avg runtime, avg memory of
+         the bounding box detection process.)
     """
     avg_runtime_secs, avg_memory_mbs = self.find_icons(find_icon_option,
                                                        output_path)
@@ -270,10 +168,16 @@ class BenchmarkPipeline:
           "images/" + find_icon_option + "/" + find_icon_option +
           "-visualized", self.proposed_boxes)
     if multi_instance_icon:
-      accuracy = self.multi_instance_eval()
+      accuracy, precision, recall = util.evaluate_proposed_bounding_boxes(
+          iou_threshold, self.proposed_boxes, self.gold_boxes, output_path)
     else:
-      accuracy = self.single_instance_eval(iou_threshold, output_path)
-    return accuracy, avg_runtime_secs, avg_memory_mbs
+      accuracy, precision, recall = util.evaluate_proposed_bounding_boxes(
+          iou_threshold,
+          [[boxes[0]] for boxes in self.proposed_boxes],
+          [[boxes[0]] for boxes in self.gold_boxes],
+          output_path
+      )
+    return accuracy, precision, recall, avg_runtime_secs, avg_memory_mbs
 
 
 if __name__ == "__main__":

--- a/modules/bounding_box.py
+++ b/modules/bounding_box.py
@@ -9,16 +9,16 @@ class BoundingBox:
    Assumes each coordinate corresponds to a pixel, and
     therefore is zero-indexed.
   """
-  min_x: float
-  min_y: float
-  max_x: float
-  max_y: float
+  min_x: int
+  min_y: int
+  max_x: int
+  max_y: int
 
   def __init__(self, min_x: float, min_y: float, max_x: float, max_y: float):
-    self.min_x = min_x
-    self.min_y = min_y
-    self.max_x = max_x
-    self.max_y = max_y
+    self.min_x = int(min_x)
+    self.min_y = int(min_y)
+    self.max_x = int(max_x)
+    self.max_y = int(max_y)
 
   def calculate_area(self) -> float:
     # add one in calculations because pixel numbers are 0-indexed

--- a/modules/bounding_box.py
+++ b/modules/bounding_box.py
@@ -2,7 +2,7 @@
 import dataclasses
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(eq=True, frozen=True)
 class BoundingBox:
   """Class for keeping track of a bounding box's coordinates.
 
@@ -15,10 +15,10 @@ class BoundingBox:
   max_y: int
 
   def __init__(self, min_x: float, min_y: float, max_x: float, max_y: float):
-    self.min_x = int(min_x)
-    self.min_y = int(min_y)
-    self.max_x = int(max_x)
-    self.max_y = int(max_y)
+    object.__setattr__(self, "min_x", int(min_x))
+    object.__setattr__(self, "min_y", int(min_y))
+    object.__setattr__(self, "max_x", int(max_x))
+    object.__setattr__(self, "max_y", int(max_y))
 
   def calculate_area(self) -> float:
     # add one in calculations because pixel numbers are 0-indexed

--- a/modules/bounding_box.py
+++ b/modules/bounding_box.py
@@ -2,7 +2,7 @@
 import dataclasses
 
 
-@dataclasses.dataclass(eq=True, frozen=True)
+@dataclasses.dataclass
 class BoundingBox:
   """Class for keeping track of a bounding box's coordinates.
 
@@ -15,10 +15,10 @@ class BoundingBox:
   max_y: int
 
   def __init__(self, min_x: float, min_y: float, max_x: float, max_y: float):
-    object.__setattr__(self, "min_x", int(min_x))
-    object.__setattr__(self, "min_y", int(min_y))
-    object.__setattr__(self, "max_x", int(max_x))
-    object.__setattr__(self, "max_y", int(max_y))
+    self.min_x = min_x
+    self.min_y = min_y
+    self.max_x = max_x
+    self.max_y = max_y
 
   def calculate_area(self) -> float:
     # add one in calculations because pixel numbers are 0-indexed

--- a/modules/correctness_metrics.py
+++ b/modules/correctness_metrics.py
@@ -1,0 +1,18 @@
+"""This module contains a CorrectnessMetrics class."""
+import dataclasses
+
+
+@dataclasses.dataclass
+class CorrectnessMetrics:
+  """Class for keeping track of the correctness results of an experiment.
+
+   Correctness is measured in terms of accuracy, precision, and recall.
+  """
+  accuracy: float
+  precision: float
+  recall: float
+
+  def __init__(self, accuracy: float, precision: float, recall: float):
+    self.accuracy = accuracy
+    self.precision = precision
+    self.recall = recall

--- a/modules/util.py
+++ b/modules/util.py
@@ -1,16 +1,193 @@
 """Contains utility classes.
 
 So far, we have classes that measure latency and
-memory usage.
+memory usage, image processing utility functions,
+and evaluation functions.
 """
 import cProfile
 import io
 import pstats
+from typing import Any, List, Tuple
 
+import cv2
 import memory_profiler
-
+from modules.bounding_box import BoundingBox
 import modules.defaults as defaults
 import numpy as np
+import tensorflow as tf
+
+_IMAGE_FEATURE_DESCRIPTION = {
+    "encoded_image_png": tf.io.FixedLenFeature([], tf.string),
+    "encoded_icon_png": tf.io.FixedLenFeature([], tf.string),
+    "box_ymin": tf.io.FixedLenSequenceFeature([],
+                                              tf.float32,
+                                              allow_missing=True),
+    "box_xmin": tf.io.FixedLenSequenceFeature([],
+                                              tf.float32,
+                                              allow_missing=True),
+    "box_ymax": tf.io.FixedLenSequenceFeature([],
+                                              tf.float32,
+                                              allow_missing=True),
+    "box_xmax": tf.io.FixedLenSequenceFeature([],
+                                              tf.float32,
+                                              allow_missing=True),
+}
+
+
+def _parse_image_function(
+    example_proto: tf.python.framework.ops.Tensor) -> Any:
+  return tf.io.parse_single_example(example_proto, _IMAGE_FEATURE_DESCRIPTION)
+
+
+def parse_image_dataset(
+    path: str) -> tf.python.data.ops.dataset_ops.MapDataset:
+  raw_dataset = tf.data.TFRecordDataset(path)
+  parsed_image_dataset = raw_dataset.map(_parse_image_function)
+  return parsed_image_dataset
+
+
+def parse_gold_boxes(
+    parsed_image_dataset: tf.python.data.ops.dataset_ops.MapDataset
+) -> List[List[BoundingBox]]:
+  """Retrieve a list of bounding boxes from dataset.
+
+  Arguments:
+      parsed_image_dataset: Original dataset read from TFRecord
+
+  Returns:
+      List of lists of ground truth BoundingBoxes.
+  """
+  all_images_gold_boxes = []
+  for image_features in parsed_image_dataset:
+    single_image_gold_boxes = []
+    for xmin, ymin, xmax, ymax in zip(image_features["box_xmin"],
+                                      image_features["box_ymin"],
+                                      image_features["box_xmax"],
+                                      image_features["box_ymax"]):
+      gold_box = BoundingBox(xmin, ymin, xmax, ymax)
+      single_image_gold_boxes.append(gold_box)
+    all_images_gold_boxes.append(single_image_gold_boxes)
+  return all_images_gold_boxes
+
+
+def parse_images_and_icons(
+    parsed_image_dataset: tf.python.data.ops.dataset_ops.MapDataset
+) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+  """Private function for parsing images and icons.
+
+  Arguments:
+      parsed_image_dataset: image dataset read from TFRecord
+
+  Returns:
+      (List of images, List of icons)
+  """
+  image_list = []
+  icon_list = []
+  for image_features in parsed_image_dataset:
+    image_raw = image_features["encoded_image_png"].numpy()
+    image_bgr = cv2.imdecode(np.frombuffer(image_raw, dtype=np.uint8), -1)
+    image_list.append(image_bgr)
+    icon_raw = image_features["encoded_icon_png"].numpy()
+    icon_bgr = cv2.imdecode(np.frombuffer(icon_raw, dtype=np.uint8), -1)
+    icon_list.append(icon_bgr)
+  return image_list, icon_list
+
+
+def _count_true_false_pos_neg(
+    iou_threshold: float, proposed_boxes: List[List[BoundingBox]],
+    gold_boxes: List[List[BoundingBox]]) -> Tuple[float, float, float, float]:
+  """Count the number of true pos, true neg, false pos, false neg in proposed boxes.
+
+  Arguments:
+      iou_threshold: a proposed box that has an IOU with a gold box below this
+       threshold is effectively a distinct and separate box.
+      proposed_boxes: a list of BoundingBox lists, one for each image,
+       as the proposed box.
+      gold_boxes: a list of BoundingBox lists, one for each image,
+       as the ground truth.
+
+  Returns:
+      Tuple(Number of false pos, false neg, true pos, true neg)
+  """
+  num_false_pos = 0
+  num_false_neg = 0
+  num_true_pos = 0
+  num_true_neg = 0
+  for proposed_box_list, gold_box_list in zip(proposed_boxes, gold_boxes):
+    matches = {}
+    for proposed_box in proposed_box_list:
+      # find the gold box that maximizes IOU
+      max_iou = 0
+      max_gold_box = None
+      for gold_box in gold_box_list:
+        iou = proposed_box.calculate_iou(gold_box)
+        if iou > max_iou:
+          max_iou = iou
+          max_gold_box = gold_box
+      # update matches
+      proposed_iou = max_iou
+      if max_gold_box in matches:
+        num_false_pos += 1
+        current_max_iou = matches[max_gold_box]
+        if current_max_iou > proposed_iou:
+          proposed_iou = matches[max_gold_box]
+      matches[max_gold_box] = proposed_iou
+    # evaluate matches with double penalty for mismatches
+    current_true_pos = np.sum(
+        [1 if iou >= iou_threshold else 0 for iou in matches.values()])
+    num_true_pos += current_true_pos
+    num_false_pos += len(matches) - current_true_pos
+    num_false_neg += len(matches) - current_true_pos
+    num_false_neg += len(gold_box_list) - len(matches)
+    if not proposed_box_list and not gold_box_list:
+      num_true_neg += 1
+  return num_false_pos, num_false_neg, num_true_pos, num_true_neg
+
+
+def evaluate_proposed_bounding_boxes(
+    iou_threshold: float,
+    proposed_boxes: List[List[BoundingBox]],
+    gold_boxes: List[List[BoundingBox]],
+    output_path: str = defaults.OUTPUT_PATH,
+) -> Tuple[float, float, float]:
+  """Evaluates proposed boxes against gold boxes.
+
+  Arguments:
+      iou_threshold: a proposed box that has an IOU with a gold box below this
+       threshold is effectively a distinct and separate box.
+      proposed_boxes: a list of BoundingBox lists, one for each image,
+       as the proposed box.
+      gold_boxes: a list of BoundingBox lists, one for each image,
+       as the ground truth.
+      output_path: if not None, prints accuracy, precision, and recall
+       to file at path.
+
+  Returns:
+      Tuple(accuracy, precision, recall)
+  """
+  num_false_pos, num_false_neg, num_true_pos, num_true_neg = _count_true_false_pos_neg(
+      iou_threshold, proposed_boxes, gold_boxes)
+  accuracy = (num_true_pos + num_true_neg) / (num_true_pos + num_true_neg +
+                                              num_false_pos + num_false_neg)
+  if num_true_pos == 0 and num_false_pos == 0:
+    precision = 1
+  else:
+    precision = num_true_pos / (num_true_pos + num_false_pos)
+  if num_true_pos == 0 and num_false_neg == 0:
+    recall = 1
+  else:
+    recall = num_true_pos / (num_true_pos + num_false_neg)
+
+  if output_path:
+    with open(output_path, "a") as output_file:
+      output_file.write("Accuracy: %f\n" % accuracy)
+      output_file.write("Precision: %f\n" % precision)
+      output_file.write("Recall: %f\n" % recall)
+
+  print("Accuracy: %f\n" % accuracy)
+  print("Precision: %f\n" % precision)
+  print("Recall: %f\n" % recall)
+  return accuracy, precision, recall
 
 
 class LatencyTimer:

--- a/modules/util.py
+++ b/modules/util.py
@@ -124,7 +124,8 @@ def _count_true_false_pos_neg(
         if iou > max_iou:
           max_iou = iou
           max_gold_box = gold_box
-      # update matches
+      # if the gold box already has a match, increase false positives
+      # (condition holds even if there are no gold boxes; max_gold_box = None)
       proposed_iou = max_iou
       if max_gold_box in matches:
         num_false_pos += 1

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1,6 +1,7 @@
 from modules import util
 import modules.benchmark_pipeline
 from modules.bounding_box import BoundingBox
+from modules.correctness_metrics import CorrectnessMetrics
 import pytest
 
 _BOX_A = BoundingBox(20, 20, 29, 29)
@@ -10,6 +11,15 @@ _BOX_D = BoundingBox(2, 3, 4, 5)
 _BOX_E = BoundingBox(3, 1, 4, 2)
 _BOX_F = BoundingBox(2, 2, 3, 3)
 _BOX_G = BoundingBox(2, 1, 3, 2)
+# The following two test suites test the IOU calculation for bounding boxes
+# in these cases, in order:
+# -- partial overlap between boxes (diagonal on upper right)
+# -- no overlap between bounding boxes
+# -- one box within another box
+# -- partial overlap between boxes (diagonal square on upper right)
+# -- partial overlap between boxes (exactly one pixel, on upper left)
+# -- partial overlap between boxes (an entire top/bottom side)
+# -- partial overlap between boxes (an entire left/right side)
 # covers: no overlap, 1 box overlap, overlap an entire side, partial overlap
 bounding_box_tests = [(_BOX_A, _BOX_B, 25 / 700), (_BOX_A, _BOX_C, 0),
                       (_BOX_B, _BOX_C, 9 / 625), (_BOX_C, _BOX_D, 4 / 14),
@@ -27,35 +37,71 @@ box_list_2 = [[_BOX_B, _BOX_A], [_BOX_D, _BOX_C]]
 box_list_3 = [[_BOX_A], [_BOX_C]]
 box_list_4 = [[_BOX_E], [_BOX_F]]
 box_list_5 = [[_BOX_G], [_BOX_G]]
-# Tests proper matching of proposed box to gold box, IOU thresholds
-# includes double penalty for false positive and false negative if
-# a proposed box doesn't match the IOU threshold and there exists a gold box
-# Also includes empty edge cases
-evaluation_tests = [(1, box_list_1, box_list_2, (1, 1, 1)),
-                    (1, box_list_1, box_list_3, (0.5, 0.5, 1)),
-                    (1, box_list_3, box_list_1, (0.5, 1, 0.5)),
-                    (1, [[]], [[]], (1, 1, 1)),
-                    (1, [[], []], box_list_3, (0, 1, 0)),
-                    (1, box_list_3, [[], []], (0, 0, 1)),
-                    (2 / 6, box_list_4, box_list_5, (1, 1, 1)),
-                    (1, box_list_3, box_list_5, (0, 0, 0))]
+# The following two test suites test the evaluation functionality for
+# these cases, in order:
+# -- proposed boxes that are all correct but not listed in the same order
+#    as gold boxes
+# -- extra proposed box present, beyond a correct one
+# -- one fewer proposed box present, besides a correct one
+# -- no gold or proposed boxes present
+# -- no proposed boxes but there are gold boxes present
+# -- there are proposed boxes returned but no gold boxes present
+# -- proposed boxes that have an IOU with the gold boxes *exactly* at the IOU
+#    threshold
+# -- proposed boxes that have an IOU with the gold boxes below the IOU threshold
+#    in particular, each proposed box is a false positive, and each gold box is
+#    a false negative (double penalty)
+
+# test the final accuracy, precision, and recall values
+correctness_evaluation_tests = [
+    (1, box_list_1, box_list_2, CorrectnessMetrics(1, 1, 1)),
+    (1, box_list_1, box_list_3, CorrectnessMetrics(0.5, 0.5, 1)),
+    (1, box_list_3, box_list_1, CorrectnessMetrics(0.5, 1, 0.5)),
+    (1, [[]], [[]], CorrectnessMetrics(1, 1, 1)),
+    (1, [[], []], box_list_3, CorrectnessMetrics(0, 1, 0)),
+    (1, box_list_3, [[], []], CorrectnessMetrics(0, 0, 1)),
+    (2 / 6, box_list_4, box_list_5, CorrectnessMetrics(1, 1, 1)),
+    (1, box_list_3, box_list_5, CorrectnessMetrics(0, 0, 0))
+]
+
+# explicitly test the intermediate confusion matrix values
+#   specifically, a regression test for a case where there were zero gold
+#   boxes but nonzero proposed boxes, and the final accuracy/precison/recall
+#   values were correct, but not the intermediate confusion matrix values
+#   ((false positive, false negative), (true positive, true negative))
+confusion_matrix_tests = [(1, box_list_1, box_list_2, ((0, 0), (4, 0))),
+                          (1, box_list_1, box_list_3, ((2, 0), (2, 0))),
+                          (1, box_list_3, box_list_1, ((0, 2), (2, 0))),
+                          (1, [[]], [[]], ((0, 0), (0, 1))),
+                          (1, [[], []], box_list_3, ((0, 2), (0, 0))),
+                          (1, box_list_3, [[], []], ((2, 0), (0, 0))),
+                          (2 / 6, box_list_4, box_list_5, ((0, 0), (2, 0))),
+                          (1, box_list_3, box_list_5, ((2, 2), (0, 0)))]
 
 
-# expected is a tuple: (accuracy, precision, recall)
+# "expected": CorrectnessMetrics dataclass object (accuracy, precision, recall)
 @pytest.mark.parametrize("iou_threshold,proposed_boxes,gold_boxes,expected",
-                         evaluation_tests)
+                         correctness_evaluation_tests)
 def test_evaluate_proposed_bounding_boxes(iou_threshold, proposed_boxes,
                                           gold_boxes, expected):
   assert util.evaluate_proposed_bounding_boxes(iou_threshold, proposed_boxes,
                                                gold_boxes) == expected
 
 
+# "expected": num of ((false pos, false neg), (true pos, true neg))
+@pytest.mark.parametrize("iou_threshold,proposed_boxes,gold_boxes,expected",
+                         confusion_matrix_tests)
+def test_get_confusion_matrix(iou_threshold, proposed_boxes, gold_boxes,
+                              expected):
+  assert util.get_confusion_matrix(iou_threshold, proposed_boxes,
+                                   gold_boxes) == expected
+
+
 def test_benchmark():
   find_icon_benchmark = modules.benchmark_pipeline.BenchmarkPipeline()
-  accuracy, precision, recall, avg_time_secs, avg_memory_mibs = find_icon_benchmark.evaluate(
-  )
+  correctness, avg_time_secs, avg_memory_mibs = find_icon_benchmark.evaluate()
   assert avg_memory_mibs <= 1000
   assert avg_time_secs <= 60
-  assert accuracy >= 0
-  assert precision >= 0
-  assert recall >= 0
+  assert correctness.accuracy >= 0
+  assert correctness.precision >= 0
+  assert correctness.recall >= 0

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -41,6 +41,7 @@ evaluation_tests = [(1, box_list_1, box_list_2, (1, 1, 1)),
                     (1, box_list_3, box_list_5, (0, 0, 0))]
 
 
+# expected is a tuple: (accuracy, precision, recall)
 @pytest.mark.parametrize("iou_threshold,proposed_boxes,gold_boxes,expected",
                          evaluation_tests)
 def test_evaluate_proposed_bounding_boxes(iou_threshold, proposed_boxes,

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1,19 +1,20 @@
+from modules import util
 import modules.benchmark_pipeline
 from modules.bounding_box import BoundingBox
 import pytest
 
-box_a = BoundingBox(20, 20, 29, 29)
-box_b = BoundingBox(0, 0, 24, 24)
-box_c = BoundingBox(1, 2, 3, 4)
-box_d = BoundingBox(2, 3, 4, 5)
-box_e = BoundingBox(3, 1, 4, 2)
-box_f = BoundingBox(2, 2, 3, 3)
-box_g = BoundingBox(2, 1, 3, 2)
+_BOX_A = BoundingBox(20, 20, 29, 29)
+_BOX_B = BoundingBox(0, 0, 24, 24)
+_BOX_C = BoundingBox(1, 2, 3, 4)
+_BOX_D = BoundingBox(2, 3, 4, 5)
+_BOX_E = BoundingBox(3, 1, 4, 2)
+_BOX_F = BoundingBox(2, 2, 3, 3)
+_BOX_G = BoundingBox(2, 1, 3, 2)
 # covers: no overlap, 1 box overlap, overlap an entire side, partial overlap
-bounding_box_tests = [(box_a, box_b, 25 / 700), (box_a, box_c, 0),
-                      (box_b, box_c, 9 / 625), (box_c, box_d, 4 / 14),
-                      (box_e, box_f, 1 / 7), (box_f, box_g, 2 / 6),
-                      (box_e, box_g, 2 / 6)]
+bounding_box_tests = [(_BOX_A, _BOX_B, 25 / 700), (_BOX_A, _BOX_C, 0),
+                      (_BOX_B, _BOX_C, 9 / 625), (_BOX_C, _BOX_D, 4 / 14),
+                      (_BOX_E, _BOX_F, 1 / 7), (_BOX_F, _BOX_G, 2 / 6),
+                      (_BOX_E, _BOX_G, 2 / 6)]
 
 
 @pytest.mark.parametrize("box_1,box_2,expected", bounding_box_tests)
@@ -21,9 +22,39 @@ def test_iou(box_1, box_2, expected):
   assert box_1.calculate_iou(box_2) == expected
 
 
+box_list_1 = [[_BOX_A, _BOX_B], [_BOX_C, _BOX_D]]
+box_list_2 = [[_BOX_B, _BOX_A], [_BOX_D, _BOX_C]]
+box_list_3 = [[_BOX_A], [_BOX_C]]
+box_list_4 = [[_BOX_E], [_BOX_F]]
+box_list_5 = [[_BOX_G], [_BOX_G]]
+# Tests proper matching of proposed box to gold box, IOU thresholds
+# includes double penalty for false positive and false negative if
+# a proposed box doesn't match the IOU threshold and there exists a gold box
+# Also includes empty edge cases
+evaluation_tests = [(1, box_list_1, box_list_2, (1, 1, 1)),
+                    (1, box_list_1, box_list_3, (0.5, 0.5, 1)),
+                    (1, box_list_3, box_list_1, (0.5, 1, 0.5)),
+                    (1, [[]], [[]], (1, 1, 1)),
+                    (1, [[], []], box_list_3, (0, 1, 0)),
+                    (1, box_list_3, [[], []], (0, 0, 1)),
+                    (2 / 6, box_list_4, box_list_5, (1, 1, 1)),
+                    (1, box_list_3, box_list_5, (0, 0, 0))]
+
+
+@pytest.mark.parametrize("iou_threshold,proposed_boxes,gold_boxes,expected",
+                         evaluation_tests)
+def test_evaluate_proposed_bounding_boxes(iou_threshold, proposed_boxes,
+                                          gold_boxes, expected):
+  assert util.evaluate_proposed_bounding_boxes(iou_threshold, proposed_boxes,
+                                               gold_boxes) == expected
+
+
 def test_benchmark():
   find_icon_benchmark = modules.benchmark_pipeline.BenchmarkPipeline()
-  accuracy, avg_time_secs, avg_memory_mibs = find_icon_benchmark.evaluate()
+  accuracy, precision, recall, avg_time_secs, avg_memory_mibs = find_icon_benchmark.evaluate(
+  )
   assert avg_memory_mibs <= 1000
   assert avg_time_secs <= 60
   assert accuracy >= 0
+  assert precision >= 0
+  assert recall >= 0

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -34,11 +34,11 @@ def test_iou(box_1, box_2, expected):
   assert box_1.calculate_iou(box_2) == expected
 
 
-box_list_1 = [[_BOX_A, _BOX_B], [_BOX_C, _BOX_D]]
-box_list_2 = [[_BOX_B, _BOX_A], [_BOX_D, _BOX_C]]
-box_list_3 = [[_BOX_A], [_BOX_C]]
-box_list_4 = [[_BOX_E], [_BOX_F]]
-box_list_5 = [[_BOX_G], [_BOX_G]]
+_BOX_LIST_1 = [[_BOX_A, _BOX_B], [_BOX_C, _BOX_D]]
+_BOX_LIST_2 = [[_BOX_B, _BOX_A], [_BOX_D, _BOX_C]]
+_BOX_LIST_3 = [[_BOX_A], [_BOX_C]]
+_BOX_LIST_4 = [[_BOX_E], [_BOX_F]]
+_BOX_LIST_5 = [[_BOX_G], [_BOX_G]]
 # The following two test suites test the evaluation functionality for
 # these cases, in order:
 # -- proposed boxes that are all correct but not listed in the same order
@@ -56,14 +56,14 @@ box_list_5 = [[_BOX_G], [_BOX_G]]
 
 # test the final accuracy, precision, and recall values
 correctness_evaluation_tests = [
-    (1, box_list_1, box_list_2, CorrectnessMetrics(1, 1, 1)),
-    (1, box_list_1, box_list_3, CorrectnessMetrics(0.5, 0.5, 1)),
-    (1, box_list_3, box_list_1, CorrectnessMetrics(0.5, 1, 0.5)),
+    (1, _BOX_LIST_1, _BOX_LIST_2, CorrectnessMetrics(1, 1, 1)),
+    (1, _BOX_LIST_1, _BOX_LIST_3, CorrectnessMetrics(0.5, 0.5, 1)),
+    (1, _BOX_LIST_3, _BOX_LIST_1, CorrectnessMetrics(0.5, 1, 0.5)),
     (1, [[]], [[]], CorrectnessMetrics(1, 1, 1)),
-    (1, [[], []], box_list_3, CorrectnessMetrics(0, 1, 0)),
-    (1, box_list_3, [[], []], CorrectnessMetrics(0, 0, 1)),
-    (2 / 6, box_list_4, box_list_5, CorrectnessMetrics(1, 1, 1)),
-    (1, box_list_3, box_list_5, CorrectnessMetrics(0, 0, 0))
+    (1, [[], []], _BOX_LIST_3, CorrectnessMetrics(0, 1, 0)),
+    (1, _BOX_LIST_3, [[], []], CorrectnessMetrics(0, 0, 1)),
+    (2 / 6, _BOX_LIST_4, _BOX_LIST_5, CorrectnessMetrics(1, 1, 1)),
+    (1, _BOX_LIST_3, _BOX_LIST_5, CorrectnessMetrics(0, 0, 0))
 ]
 
 # explicitly test the intermediate confusion matrix values
@@ -71,14 +71,14 @@ correctness_evaluation_tests = [
 #   boxes but nonzero proposed boxes, and the final accuracy/precison/recall
 #   values were correct, but not the intermediate confusion matrix values
 #   ((false positive, false negative), (true positive, true negative))
-confusion_matrix_tests = [(1, box_list_1, box_list_2, ((0, 0), (4, 0))),
-                          (1, box_list_1, box_list_3, ((2, 0), (2, 0))),
-                          (1, box_list_3, box_list_1, ((0, 2), (2, 0))),
+confusion_matrix_tests = [(1, _BOX_LIST_1, _BOX_LIST_2, ((0, 0), (4, 0))),
+                          (1, _BOX_LIST_1, _BOX_LIST_3, ((2, 0), (2, 0))),
+                          (1, _BOX_LIST_3, _BOX_LIST_1, ((0, 2), (2, 0))),
                           (1, [[]], [[]], ((0, 0), (0, 1))),
-                          (1, [[], []], box_list_3, ((0, 2), (0, 0))),
-                          (1, box_list_3, [[], []], ((2, 0), (0, 0))),
-                          (2 / 6, box_list_4, box_list_5, ((0, 0), (2, 0))),
-                          (1, box_list_3, box_list_5, ((2, 2), (0, 0)))]
+                          (1, [[], []], _BOX_LIST_3, ((0, 2), (0, 0))),
+                          (1, _BOX_LIST_3, [[], []], ((2, 0), (0, 0))),
+                          (2 / 6, _BOX_LIST_4, _BOX_LIST_5, ((0, 0), (2, 0))),
+                          (1, _BOX_LIST_3, _BOX_LIST_5, ((2, 2), (0, 0)))]
 
 
 # "expected": CorrectnessMetrics dataclass object (accuracy, precision, recall)
@@ -128,8 +128,8 @@ icon_rect_2 = [0, 0, 7, 7]
 icon_rect_3 = [0, 0, 4, 6]
 icon_rect_4 = [0, 0, 10, 10]
 icon_rect_5 = [0, 0, 9, 10]
-icon_bbox_list_1 = [icon_bbox_1, icon_bbox_2, icon_bbox_3]
-icon_bbox_list_2 = [icon_bbox_4, icon_bbox_5]
+icon_box_list_1 = [icon_bbox_1, icon_bbox_2, icon_bbox_3]
+icon_box_list_2 = [icon_bbox_4, icon_bbox_5]
 icon_rect_list_1 = [icon_rect_1, icon_rect_2, icon_rect_3]
 icon_rect_list_2 = [icon_rect_4, icon_rect_5]
 confidence_1 = [5, 6, 7]
@@ -138,10 +138,10 @@ confidence_2 = [5, 4]
 # contour list 1: tests varying confidence thresholds given IOUs < nms_threshold
 # contour list 2: tests varying confidence thresholds given IOU > nms_threshold
 nms_tests = [
-    (icon_bbox_list_1, icon_rect_list_1, confidence_1, 2, 0.9, 3),
-    (icon_bbox_list_1, icon_rect_list_1, confidence_1, 6, 0.9, 1),
-    (icon_bbox_list_2, icon_rect_list_2, confidence_2, 3, 0.89, 1),
-    (icon_bbox_list_2, icon_rect_list_2, confidence_2, 6, 0.9, 0),
+    (icon_box_list_1, icon_rect_list_1, confidence_1, 2, 0.9, 3),
+    (icon_box_list_1, icon_rect_list_1, confidence_1, 6, 0.9, 1),
+    (icon_box_list_2, icon_rect_list_2, confidence_2, 3, 0.89, 1),
+    (icon_box_list_2, icon_rect_list_2, confidence_2, 6, 0.9, 0),
 ]
 
 


### PR DESCRIPTION
Functionality that allows for running on multiple instance of an icon in an image:
- Small tweaks to read in the TfRecord with a list of bounding boxes per image instead of one bounding box
- Generalized evaluation function that supports both single and multi-instances, by counting the number of false positives, false negatives, true positives, and true negatives, and calculating accuracy, recall, and precision

Continuous Integration Tests:
- gpylint passes locally 
- Unit tests for the general evaluation function that covers edge cases like empty lists or variable-length lists, and "double penalizing" for a proposed box that doesn't pass the IOU threshold and leaves a gold box without any matched proposed box -- this case is considered as both a false positive and a false negative. 