### PR TITLE
Upsampling from Nonkeypoints

### DIFF
--- a/modules/algorithms.py
+++ b/modules/algorithms.py
@@ -124,7 +124,7 @@ def create_pointset(keypoints: np.ndarray,
   # introduce as few nonkeypoints as possible,
   # so only try to upsample if it's less than min
   elif len(keypoints) < min_points:
-    if nonkeypoints is not None and len(nonkeypoints) > 0:
+    if nonkeypoints is not None and len(nonkeypoints) > 0:  # pylint: disable=g-explicit-length-test
       if len(keypoints) + len(nonkeypoints) <= min_points:
         selected_nonkeypoints = nonkeypoints
       else:

--- a/modules/algorithms.py
+++ b/modules/algorithms.py
@@ -100,12 +100,12 @@ def cluster_contours_dbscan(
   return contour_groups, core_samples_mask_groups
 
 
-def create_pointset(keypoints: np.ndarray,
+def resize_pointset(keypoints: np.ndarray,
                     min_points: int,
                     max_points: int,
                     nonkeypoints: np.ndarray = None,
                     random_seed: int = 0) -> np.ndarray:
-  """Downsample and upsample pointset to a certain size.
+  """Resize pointset to be within [min, max] whenever possible.
 
   If there are enough keypoints and nonkeypoints, the resulting pointset
   will be at least min_points large. In all cases, the resulting pointset

--- a/modules/algorithms.py
+++ b/modules/algorithms.py
@@ -106,7 +106,7 @@ def create_pointset(keypoints: np.ndarray,
 
   Arguments:
       keypoints: an array of [x, y] points representing keypoints
-      min_points: the minimum desired number of poitns we want in pointset
+      min_points: the minimum desired number of points we want in pointset
       max_points: the upper limit of points we want in point set
       nonkeypoints: an optional array of [x, y] points representing nonkeypoints
         If provided, these points will be used to bring the pointset size up to

--- a/modules/algorithms.py
+++ b/modules/algorithms.py
@@ -109,7 +109,9 @@ def create_pointset(keypoints: np.ndarray,
 
   If there are enough keypoints and nonkeypoints, the resulting pointset
   will be at least min_points large. In all cases, the resulting pointset
-  will be less than or equal to max_points in size.
+  will be less than or equal to max_points in size. Nonkeypoints are used
+  to bring the size up to min_points if needed (upsampling). Keypoints are only
+  downsampled if the current size is greater than max_points.
 
   Arguments:
       keypoints: an array of [x, y] points representing keypoints
@@ -132,31 +134,23 @@ def create_pointset(keypoints: np.ndarray,
   num_nonkeypoints = 0
   if nonkeypoints is not None:
     num_nonkeypoints = nonkeypoints.shape[0]
-  pointset = []
-  # keep as many keypoints as possible,
-  # so only downsample if there's more than max
+  pointset = keypoints
+
   if num_keypoints > max_points:
+    # downsample as few keypoints as possible
     pointset = keypoints[
         random_state.choice(num_keypoints, max_points, replace=False), :]
 
-  # introduce as few nonkeypoints as possible,
-  # so only try to upsample if it's less than min
   elif num_keypoints < min_points:
     if num_nonkeypoints:
       if num_keypoints + num_nonkeypoints <= min_points:
         selected_nonkeypoints = nonkeypoints
       else:
+        # upsample as few nonkeypoints as possible
         selected_nonkeypoints = nonkeypoints[random_state.choice(
             num_nonkeypoints, min_points - num_keypoints, replace=False), :]
       pointset = np.concatenate((keypoints, selected_nonkeypoints))
-    # if there are no nonkeypoints supplied,
-    # there's no choice but to just use keypoints
-    else:
-      pointset = keypoints
 
-  # the number of keypoints is already within the range [min, max]
-  else:
-    pointset = keypoints
   return pointset
 
 

--- a/modules/algorithms.py
+++ b/modules/algorithms.py
@@ -119,23 +119,28 @@ def create_pointset(keypoints: np.ndarray,
   """
   # set the random seed *locally*
   random_state = np.random.RandomState(random_seed)
+  num_keypoints = 0
+  if keypoints is not None:
+    num_keypoints = keypoints.shape[0]
+  num_nonkeypoints = 0
+  if nonkeypoints is not None:
+    num_nonkeypoints = nonkeypoints.shape[0]
   pointset = []
   # keep as many keypoints as possible,
   # so only downsample if there's more than max
-  if len(keypoints) > max_points:
+  if num_keypoints > max_points:
     pointset = keypoints[
-        random_state.choice(keypoints.shape[0], max_points, replace=False), :]
+        random_state.choice(num_keypoints, max_points, replace=False), :]
 
   # introduce as few nonkeypoints as possible,
   # so only try to upsample if it's less than min
-  elif len(keypoints) < min_points:
-    if nonkeypoints is not None and len(nonkeypoints) > 0:  # pylint:disable=g-explicit-length-test
-      if len(keypoints) + len(nonkeypoints) <= min_points:
+  elif num_keypoints < min_points:
+    if num_nonkeypoints:
+      if num_keypoints + num_nonkeypoints <= min_points:
         selected_nonkeypoints = nonkeypoints
       else:
         selected_nonkeypoints = nonkeypoints[random_state.choice(
-            nonkeypoints.shape[0], min_points -
-            len(keypoints), replace=False), :]
+            num_nonkeypoints, min_points - num_keypoints, replace=False), :]
       pointset = np.concatenate((keypoints, selected_nonkeypoints))
     # if there are no nonkeypoints supplied,
     # there's no choice but to just use keypoints

--- a/modules/algorithms.py
+++ b/modules/algorithms.py
@@ -118,16 +118,18 @@ def create_pointset(keypoints: np.ndarray,
   # keep as many keypoints as possible,
   # so only downsample if there's more than max
   if len(keypoints) > max_points:
+    np.random.seed(0)  # fix randomness used
     pointset = keypoints[
         np.random.choice(keypoints.shape[0], max_points, replace=False), :]
 
   # introduce as few nonkeypoints as possible,
   # so only try to upsample if it's less than min
   elif len(keypoints) < min_points:
-    if nonkeypoints is not None and len(nonkeypoints) > 0:  # pylint: disable=g-explicit-length-test
+    if nonkeypoints is not None and len(nonkeypoints) > 0:  # pylint:disable=g-explicit-length-test
       if len(keypoints) + len(nonkeypoints) <= min_points:
         selected_nonkeypoints = nonkeypoints
       else:
+        np.random.seed(1)  # fix randomness used
         selected_nonkeypoints = nonkeypoints[np.random.choice(
             nonkeypoints.shape[0], min_points -
             len(keypoints), replace=False), :]

--- a/modules/analysis_util.py
+++ b/modules/analysis_util.py
@@ -7,7 +7,7 @@ This contains:
 from typing import List
 
 import cv2
-import matplotlib
+import matplotlib.pyplot
 import numpy as np
 
 
@@ -51,8 +51,10 @@ def generate_histogram(samples: np.ndarray,
       output_path: file path for resulting histogram plot to be saved at
   """
   counts = samples.flatten()
+  fig = matplotlib.pyplot.figure()
   matplotlib.pyplot.hist(counts)
   matplotlib.pyplot.title(title)
   matplotlib.pyplot.xlabel("%s. Median: %f" % (xlabel, np.median(counts)))
   matplotlib.pyplot.ylabel("Frequency")
   matplotlib.pyplot.savefig(output_path)
+  matplotlib.pyplot.close(fig=fig)

--- a/modules/analysis_util.py
+++ b/modules/analysis_util.py
@@ -33,8 +33,7 @@ def label_cluster_size(image_clusters: List[np.ndarray],
       text = str(len(contour))
       cv2.putText(image, text, bottom_left, font, font_scale, color, thickness)
     matplotlib.pyplot.imshow(image)
-    matplotlib.pyplot.imsave(
-        output_path + str(index) + ".png", image)
+    matplotlib.pyplot.imsave("%s-%d.png" % (output_path, index), image)
 
 
 def generate_histogram(samples: np.ndarray,
@@ -54,6 +53,6 @@ def generate_histogram(samples: np.ndarray,
   counts = samples.flatten()
   matplotlib.pyplot.hist(counts)
   matplotlib.pyplot.title(title)
-  matplotlib.pyplot.xlabel(xlabel + ". Median: %f" % np.median(counts))
+  matplotlib.pyplot.xlabel("%s. Median: %f" % (xlabel, np.median(counts)))
   matplotlib.pyplot.ylabel("Frequency")
   matplotlib.pyplot.savefig(output_path)

--- a/modules/analysis_util.py
+++ b/modules/analysis_util.py
@@ -1,0 +1,59 @@
+"""Contains utility classes and modules used for analysis.
+
+This contains:
+- labeling the number of points in a cluster on the image
+- plotting the number of points as a histogram
+"""
+from typing import List
+
+import cv2
+import matplotlib
+import numpy as np
+
+
+def label_cluster_size(image_clusters: List[np.ndarray],
+                       image_list: List[np.ndarray], output_path: str):
+  """For each image, label all its clusters with cluster sizes.
+
+  Arguments:
+      image_clusters: List of list of clusters corresponding to each image
+      image_list: List of images
+      output_path: File path where each image is stored
+  """
+  font = cv2.FONT_HERSHEY_PLAIN
+  color = (255, 0, 0)  # blue
+  thickness = 2  # number of pixels
+  font_scale = 1  # font multiplier
+  # for each image, label each of its clusters with its size
+  for index, (clusters, image) in enumerate(zip(image_clusters, image_list)):
+    for contour in clusters:
+      contours_poly = cv2.approxPolyDP(contour, 3, True)
+      x, y, _, _ = cv2.boundingRect(contours_poly)
+      bottom_left = (x, y)
+      text = str(len(contour))
+      cv2.putText(image, text, bottom_left, font, font_scale, color, thickness)
+    matplotlib.pyplot.imshow(image)
+    matplotlib.pyplot.imsave(
+        output_path + str(index) + ".png", image)
+
+
+def generate_histogram(samples: np.ndarray,
+                       title: str,
+                       xlabel: str,
+                       output_path: str):
+  """Generate a histogram based off of samples.
+
+  Arguments:
+      samples: a potentially multi-dimensional array of samples. This is treated
+      as a one-dimensional array, where each entry is a sample whose value is
+      bucketed when creating the histogram.
+      title: title for the histogram
+      xlabel: label for the x_axis of the histogram (the y_axis is frequency)
+      output_path: file path for resulting histogram plot to be saved at
+  """
+  counts = samples.flatten()
+  matplotlib.pyplot.hist(counts)
+  matplotlib.pyplot.title(title)
+  matplotlib.pyplot.xlabel(xlabel + ". Median: %f" % np.median(counts))
+  matplotlib.pyplot.ylabel("Frequency")
+  matplotlib.pyplot.savefig(output_path)

--- a/modules/benchmark_pipeline.py
+++ b/modules/benchmark_pipeline.py
@@ -223,7 +223,7 @@ class BenchmarkPipeline:
                                        "images/labelled-contours/")
       samples = []
       for clusters in self.image_clusters:
-        samples.extend(map(len(clusters)))
+        samples.extend(map(len, clusters))
       title = "Number of keypoints in image clusters"
       analysis_util.generate_histogram(np.array(samples), title, title,
                                        "keypoints-histogram.png")

--- a/modules/benchmark_pipeline.py
+++ b/modules/benchmark_pipeline.py
@@ -26,6 +26,7 @@ class BenchmarkPipeline:
     benchmark = BenchmarkPipeline("benchmark.tfrecord")
     benchmark.evaluate()
   """
+
   def __init__(self, tfrecord_path: str = defaults.TFRECORD_PATH):
     parsed_image_dataset = util.parse_image_dataset(tfrecord_path)
     self.gold_boxes = util.parse_gold_boxes(parsed_image_dataset)

--- a/modules/benchmark_pipeline.py
+++ b/modules/benchmark_pipeline.py
@@ -223,8 +223,7 @@ class BenchmarkPipeline:
                                        "images/labelled-contours/")
       samples = []
       for clusters in self.image_clusters:
-        for cluster in clusters:
-          samples.append(len(cluster))
+        samples.extend(map(len(clusters)))
       title = "Number of keypoints in image clusters"
       analysis_util.generate_histogram(np.array(samples), title, title,
                                        "keypoints-histogram.png")

--- a/modules/benchmark_pipeline.py
+++ b/modules/benchmark_pipeline.py
@@ -5,6 +5,7 @@ from typing import Tuple
 
 import cv2
 import matplotlib.pyplot
+from modules import analysis_util
 from modules import defaults
 from modules import icon_finder_random
 from modules import icon_finder_shape_context
@@ -173,8 +174,8 @@ class BenchmarkPipeline:
       iou_threshold: float = defaults.IOU_THRESHOLD,
       output_path: str = defaults.OUTPUT_PATH,
       find_icon_option: str = defaults.FIND_ICON_OPTION,
-      multi_instance_icon: bool = False
-  ) -> Tuple[CorrectnessMetrics, float, float]:
+      multi_instance_icon: bool = False,
+      analysis_mode: bool = False) -> Tuple[CorrectnessMetrics, float, float]:
     """Integrated pipeline for testing calculated bounding boxes.
 
     Compares calculated bounding boxes to ground truth,
@@ -194,6 +195,8 @@ class BenchmarkPipeline:
         multi_instance_icon: flag for whether we're evaluating with
          multiple instances of an icon in an image
           (default: {False})
+        analysis_mode: bool for whether to run extra analyses, similar
+         to debug mode.
 
     Returns:
         Tuple(CorrectnessMetrics, avg runtime, avg memory of
@@ -212,6 +215,16 @@ class BenchmarkPipeline:
       correctness = util.evaluate_proposed_bounding_boxes(
           iou_threshold, [[boxes[0]] for boxes in self.proposed_boxes],
           [[boxes[0]] for boxes in self.gold_boxes], output_path)
+    if analysis_mode:
+      analysis_util.label_cluster_size(self.image_clusters, self.image_list,
+                                       "images/labelled-contours/")
+      samples = []
+      for clusters in self.image_clusters:
+        for cluster in clusters:
+          samples.append(len(cluster))
+      title = "Number of keypoints in image clusters"
+      analysis_util.generate_histogram(np.array(samples), title, title,
+                                       "keypoints-histogram.png")
     return correctness, avg_runtime_secs, avg_memory_mbs
 
 

--- a/modules/defaults.py
+++ b/modules/defaults.py
@@ -3,7 +3,7 @@
 This is where default configurations should be set
 and updated.
 """
-IOU_THRESHOLD = 0.3
+IOU_THRESHOLD = 0.15
 TFRECORD_PATH = "benchmark_single_instance.tfrecord"
 FIND_ICON_OPTION = "shape-context"
 OUTPUT_PATH = ""

--- a/modules/icon_finder_shape_context.py
+++ b/modules/icon_finder_shape_context.py
@@ -12,6 +12,7 @@ import numpy as np
 
 class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable=module-attr
   """This class generates bounding boxes via Shape Context Descriptors."""
+
   def __init__(self,
                desired_confidence: float = 0.5,
                dbscan_eps: float = 10,

--- a/modules/icon_finder_shape_context.py
+++ b/modules/icon_finder_shape_context.py
@@ -80,7 +80,7 @@ class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable
     nearby_contours = []
     nearby_distances = []
 
-    icon_pointset = algorithms.create_pointset(icon_contour_keypoints,
+    icon_pointset = algorithms.resize_pointset(icon_contour_keypoints,
                                                self.sc_min_num_points,
                                                self.sc_max_num_points,
                                                icon_contour_nonkeypoints)
@@ -90,7 +90,7 @@ class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable
 
     for cluster_keypoints, cluster_nonkeypoints in zip(
         image_contour_clusters_keypoints, image_contour_clusters_nonkeypoints):
-      cluster_pointset = algorithms.create_pointset(cluster_keypoints,
+      cluster_pointset = algorithms.resize_pointset(cluster_keypoints,
                                                     self.sc_min_num_points,
                                                     self.sc_max_num_points,
                                                     cluster_nonkeypoints)

--- a/modules/icon_finder_shape_context.py
+++ b/modules/icon_finder_shape_context.py
@@ -16,6 +16,7 @@ class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable
   def __init__(self,
                dbscan_eps: float = 10,
                dbscan_min_neighbors: int = 5,
+               sc_min_num_points: int = 90,
                sc_max_num_points: int = 90,
                sc_distance_threshold: float = 1,
                nms_iou_threshold: float = 0.9):
@@ -26,18 +27,22 @@ class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable
          within neighborhood of another point by DBSCAN. (default: {10})
         dbscan_min_neighbors: The number of points needed within a neighborhood
          of a point for it to be a core point by DBSCAN. (default: {5})
+        sc_min_num_points: The *desired* minimum number of points per image
+         patch passed into shape context descriptor algorithm, if possible.
+         Also applies to template icon. (default: {90})
         sc_max_num_points: The maximum number of points per image patch passed
-         into shape context descriptor algorithm; can vary slightly for icon
-         (default: {100})
+         into shape context descriptor algorithm. Also applies to template icon.
+         (default: {90})
         sc_distance_threshold: The maximum shape context distance between an
          icon and an image patch for the image patch to be under consideration
-         (default: {0.3})
+         (default: {1})
         nms_iou_threshold: The maximum IOU between two preliminary bounding
          boxes of image patches before the lower confidence one is discarded by
          non-max-suppression algorithm (default: {0.9})
     """
     self.dbscan_eps = dbscan_eps
     self.dbscan_min_neighbors = dbscan_min_neighbors
+    self.sc_min_num_points = sc_min_num_points
     self.sc_max_num_points = sc_max_num_points
     self.sc_distance_threshold = sc_distance_threshold
     self.nms_iou_threshold = nms_iou_threshold
@@ -72,7 +77,7 @@ class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable
     nearby_distances = []
 
     icon_pointset = algorithms.create_pointset(icon_contour_keypoints,
-                                               self.sc_max_num_points,
+                                               self.sc_min_num_points,
                                                self.sc_max_num_points,
                                                icon_contour_nonkeypoints)
     # expand the 1st dimension so that the shape is (n, 1, 2),
@@ -82,7 +87,7 @@ class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable
     for cluster_keypoints, cluster_nonkeypoints in zip(
         image_contour_clusters_keypoints, image_contour_clusters_nonkeypoints):
       cluster_pointset = algorithms.create_pointset(cluster_keypoints,
-                                                    self.sc_max_num_points,
+                                                    self.sc_min_num_points,
                                                     self.sc_max_num_points,
                                                     cluster_nonkeypoints)
 

--- a/modules/util.py
+++ b/modules/util.py
@@ -1,7 +1,7 @@
 """Contains utility classes and modules.
 
 Utilites include:
-- image process utility functions
+- image processing utility functions
 - evaluation utility functions
 - class that measures latency
 - class that measure memory usage

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1,6 +1,19 @@
 import modules.benchmark_pipeline
 
 
+# ------------------------------------------------------------------------
+# ---------------------- test entire benchmark pipeline -------------------
+# -------------------------------------------------------------------------
+def test_benchmark():
+  find_icon_benchmark = modules.benchmark_pipeline.BenchmarkPipeline()
+  correctness, avg_time_secs, avg_memory_mibs = find_icon_benchmark.evaluate()
+  assert avg_memory_mibs <= 1000
+  assert avg_time_secs <= 60
+  assert correctness.accuracy >= 0
+  assert correctness.precision >= 0
+  assert correctness.recall >= 0
+
+
 def test_single_instance_benchmark():
   find_icon_single_instance = modules.benchmark_pipeline.BenchmarkPipeline(
       tfrecord_path="datasets/benchmark_single_instance.tfrecord")

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -207,5 +207,5 @@ pointset_tests = [(keypoints_1, 2, 3, nonkeypoints_1, 3),
 def test_create_pointset(keypoints, min_points, max_points, nonkeypoints,
                          expected):
   assert len(
-      algorithms.create_pointset(keypoints, min_points, max_points,
+      algorithms.resize_pointset(keypoints, min_points, max_points,
                                  nonkeypoints, random_seed=0)) == expected

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -187,12 +187,12 @@ def test_get_nms_bounding_boxes(bboxes, rects, confidences,
 # -- number of keypoints is more than max
 # -- number of keypoints is exactly min
 # -- number of keypoints is less than max and more than min
-keypoints_1 = np.random.rand(3, 2)
-keypoints_2 = np.random.rand(6, 2)
-keypoints_3 = np.random.rand(5, 2)
-nonkeypoints_1 = np.random.rand(4, 2)
-nonkeypoints_2 = np.random.rand(7, 2)
-nonkeypoints_3 = np.random.rand(8, 2)
+keypoints_1 = np.full((3, 2), 1)
+keypoints_2 = np.full((6, 2), 1)
+keypoints_3 = np.full((5, 2), 1)
+nonkeypoints_1 = np.full((4, 2), 1)
+nonkeypoints_2 = np.full((7, 2), 1)
+nonkeypoints_3 = np.full((8, 2), 1)
 
 pointset_tests = [(keypoints_1, 2, 3, nonkeypoints_1, 3),
                   (keypoints_2, 7, 7, nonkeypoints_2, 7),
@@ -209,7 +209,7 @@ def test_create_pointset(keypoints, min_points, max_points, nonkeypoints,
                          expected):
   assert len(
       algorithms.create_pointset(keypoints, min_points, max_points,
-                                 nonkeypoints)) == expected
+                                 nonkeypoints, random_seed=0)) == expected
 
 
 # ------------------------------------------------------------------------


### PR DESCRIPTION
One of the challenges with getting our recall higher was that icons with fewer keypoints (ie, smaller icons) were not being properly compared by the shape context descriptor algorithm. Also, the algorithm adds random noise whenever there is a discrepancy between the number of points in the two input pointsets. This code addresses the issue by upsampling/downsampling so that the number of points are as close as possible (within a [min, max] range). Because of the minimum, smaller icons are covered as well -- the difference is made up from upsampling from nonkeypoints. These improvements bring our recall up to 93-96% for multi-instance and multi-part datasets (each of which have 160+ instances -- meaning only 5 or 6 instances are missed). 

Upsampling from nonkeypoints:
- upsample from nonkeypoints whenever the number of keypoints is less than a min value; otherwise, if keypoints is more than a max value, downsample. If keypoints is in [min, max], do nothing.
- also includes analysis functionality to help make data-driven decisions, including a visualization of the number of keypoints in a cluster, and plotting histogram utility
- this is done for both the icon and the image; previously, we've tried using all the points in the icon or only the keypoints without upsampling, but this is not robust to varying icon sizes across datasets.

Tests:
- Unit test for the upsampling and downsampling functionality
- gpylint passes locally