### PR TITLE
Standardize Padding for Bounding Boxes

### DIFF
--- a/modules/algorithms.py
+++ b/modules/algorithms.py
@@ -267,6 +267,41 @@ def suppress_overlapping_bounding_boxes(
   return [bboxes[i[0]] for i in indices]
 
 
+def _pad_bounding_box(icon_horizontal_padding_ratio: float,
+                      icon_vertical_padding_ratio: float, image_height: int,
+                      image_width: int, bbox: BoundingBox) -> BoundingBox:
+  """Adds padding to bounding box according to padding ratios provided.
+
+  Ensures that the padding added to the bounding box will not make it
+  out of the image's height and width bounds. Takes the horizontal and
+  vertical padding ratio and multiplies by the bounding box's current
+  width and height to determine how much padding to add to the left/right
+  and top/bottom, respectively.
+
+  Arguments:
+      icon_horizontal_padding_ratio: padding to width ratio for *both*
+       the left and right side.
+      icon_vertical_padding_ratio: padding to height ratio for *both*
+      the top and the bottom.
+      image_height: height of the image
+      image_width: width of the image
+      bbox: unpadded bounding box
+
+  Returns:
+      The original bounding box, except with dimensions altered to
+      include padding as long as the image's height/width allow it.
+  """
+  bbox_width = bbox.max_x - bbox.min_x + 1
+  bbox_height = bbox.max_y - bbox.min_y + 1
+  bbox_horizontal_padding = int(bbox_width * icon_horizontal_padding_ratio)
+  bbox_vertical_padding = int(bbox_height * icon_vertical_padding_ratio)
+  padded_max_x = min(image_width - 1, bbox.max_x + bbox_horizontal_padding)
+  padded_min_x = max(0, bbox.min_x - bbox_horizontal_padding)
+  padded_max_y = min(image_height - 1, bbox.max_y + bbox_vertical_padding)
+  padded_min_y = max(0, bbox.min_y - bbox_vertical_padding)
+  return BoundingBox(padded_min_x, padded_min_y, padded_max_x, padded_max_y)
+
+
 def standardize_bounding_boxes_padding(
     proposed_boxes_unpadded: List[BoundingBox], icon_box_unpadded: BoundingBox,
     icon: np.ndarray, image: np.ndarray) -> List[BoundingBox]:
@@ -285,7 +320,9 @@ def standardize_bounding_boxes_padding(
       image: the UI image
 
   Returns:
-      List[BoundingBox] -- [description]
+      List[BoundingBox]: List of the original Bounding Boxes, except with
+      dimensions altered to include proportional padding according to the
+      template icon's padding ratios.
   """
   icon_height = icon.shape[0]
   icon_width = icon.shape[1]
@@ -298,18 +335,10 @@ def standardize_bounding_boxes_padding(
                                 2)  # for both left and right
   icon_horizontal_padding_ratio = icon_horizontal_padding / icon_box_width
 
-  proposed_boxes_padded = []
   image_height = image.shape[0]
   image_width = image.shape[1]
-  for bbox in proposed_boxes_unpadded:
-    bbox_width = bbox.max_x - bbox.min_x + 1
-    bbox_height = bbox.max_y - bbox.min_y + 1
-    bbox_horizontal_padding = int(bbox_width * icon_horizontal_padding_ratio)
-    bbox_vertical_padding = int(bbox_height * icon_vertical_padding_ratio)
-    padded_max_x = min(image_width - 1, bbox.max_x + bbox_horizontal_padding)
-    padded_min_x = max(0, bbox.min_x - bbox_horizontal_padding)
-    padded_max_y = min(image_height - 1, bbox.max_y + bbox_vertical_padding)
-    padded_min_y = max(0, bbox.min_y - bbox_vertical_padding)
-    proposed_boxes_padded.append(
-        BoundingBox(padded_min_x, padded_min_y, padded_max_x, padded_max_y))
-  return proposed_boxes_padded
+  return [
+      _pad_bounding_box(icon_horizontal_padding_ratio,
+                        icon_vertical_padding_ratio, image_height, image_width,
+                        bbox) for bbox in proposed_boxes_unpadded
+  ]

--- a/modules/algorithms.py
+++ b/modules/algorithms.py
@@ -324,10 +324,9 @@ def standardize_bounding_boxes_padding(
       dimensions altered to include proportional padding according to the
       template icon's padding ratios.
   """
-  icon_height = icon.shape[0]
-  icon_width = icon.shape[1]
-  icon_box_height = icon_box_unpadded.max_y - icon_box_unpadded.min_y + 1
-  icon_box_width = icon_box_unpadded.max_x - icon_box_unpadded.min_x + 1
+  icon_height, icon_width = icon.shape[:2]
+  icon_box_height = icon_box_unpadded.get_height()
+  icon_box_width = icon_box_unpadded.get_width()
   icon_vertical_padding = max(0, (icon_height - icon_box_height) /
                               2)  # for both top and bottom
   icon_vertical_padding_ratio = icon_vertical_padding / icon_box_height
@@ -335,8 +334,7 @@ def standardize_bounding_boxes_padding(
                                 2)  # for both left and right
   icon_horizontal_padding_ratio = icon_horizontal_padding / icon_box_width
 
-  image_height = image.shape[0]
-  image_width = image.shape[1]
+  image_height, image_width = image.shape[:2]
   return [
       _pad_bounding_box(icon_horizontal_padding_ratio,
                         icon_vertical_padding_ratio, image_height, image_width,

--- a/modules/bounding_box.py
+++ b/modules/bounding_box.py
@@ -20,6 +20,12 @@ class BoundingBox:
     self.max_x = int(max_x)
     self.max_y = int(max_y)
 
+  def get_width(self) -> int:
+    return self.max_x - self.min_x + 1
+
+  def get_height(self) -> int:
+    return self.max_y - self.min_y + 1
+
   def calculate_area(self) -> float:
     # add one in calculations because pixel numbers are 0-indexed
     return (self.max_x - self.min_x + 1) * (self.max_y - self.min_y + 1)

--- a/modules/defaults.py
+++ b/modules/defaults.py
@@ -3,7 +3,7 @@
 This is where default configurations should be set
 and updated.
 """
-IOU_THRESHOLD = 0.15
+IOU_THRESHOLD = 0.6
 TFRECORD_PATH = "datasets/benchmark_single_instance.tfrecord"
 FIND_ICON_OPTION = "shape-context"
 OUTPUT_PATH = ""

--- a/modules/icon_finder_shape_context.py
+++ b/modules/icon_finder_shape_context.py
@@ -187,4 +187,8 @@ class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable
     bboxes = algorithms.suppress_overlapping_bounding_boxes(
         bboxes, rects, 1 / sorted_distances, 1 / self.sc_distance_threshold,
         self.nms_iou_threshold)
+    icon_bbox, _ = algorithms.get_bounding_boxes_from_contours(
+        np.array([icon_contour_keypoints]))
+    bboxes = algorithms.standardize_bounding_boxes_padding(
+        bboxes, icon_bbox[0], icon, image)
     return bboxes, image_contours_clusters_keypoints

--- a/modules/util.py
+++ b/modules/util.py
@@ -1,4 +1,4 @@
-"""Contains utility classes and modules.
+"""Contains utility classes and modules, generally for the benchmark pipeline.
 
 Utilites include:
 - image processing utility functions

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -207,5 +207,52 @@ pointset_tests = [(keypoints_1, 2, 3, nonkeypoints_1, 3),
 def test_create_pointset(keypoints, min_points, max_points, nonkeypoints,
                          expected):
   assert len(
-      algorithms.resize_pointset(keypoints, min_points, max_points,
-                                 nonkeypoints, random_seed=0)) == expected
+      algorithms.resize_pointset(keypoints,
+                                 min_points,
+                                 max_points,
+                                 nonkeypoints,
+                                 random_seed=0)) == expected
+
+
+# ------------------------------------------------------------------------
+# ---------------------- test standardization of padding ------------------
+# -------------------------------------------------------------------------
+# The following test suite tests the creation of pointsets of a certain desired
+# size in these cases, in order:
+# -- padding ratio would lead to a desired padding that isn't an integer
+# -- padding ratio would lead to a desired padding that is an integer
+# -- padding ratio that's different vertically from horizontally
+# -- having no padding at all
+# -- with the desired padding the proposed bounding box would be out of range
+#     of the image (testing both the x and y axis)
+template_icon_1 = np.full((4, 4, 3), 1)
+bbox_1 = BoundingBox(1, 1, 2, 2)  # padding ratio is 1/2 horiz, 1/2 vert
+template_icon_2 = np.full((7, 8, 3), 1)
+bbox_2 = BoundingBox(1, 1, 6, 5)  # padding ratio is 1/6 horiz, 1/5 vert
+template_icon_3 = np.full((5, 2, 3), 1)
+bbox_3 = BoundingBox(0, 0, 1, 4)  # padding is zero
+image_1 = np.full((10, 9, 3), 1)
+
+standardize_padding_tests = [
+    ([BoundingBox(3, 3, 5, 5)], bbox_1, template_icon_1, image_1,
+     [BoundingBox(2, 2, 6, 6)]),
+    ([BoundingBox(3, 3, 6, 6)], bbox_1, template_icon_1, image_1,
+     [BoundingBox(1, 1, 8, 8)]),
+    ([BoundingBox(1, 1, 5, 5)], bbox_2, template_icon_2, image_1,
+     [BoundingBox(1, 0, 5, 6)]),
+    ([BoundingBox(1, 1, 5, 5)], bbox_3, template_icon_3, image_1,
+     [BoundingBox(1, 1, 5, 5)]),
+    ([BoundingBox(1, 1, 8, 8)], bbox_1, template_icon_1, image_1,
+     [BoundingBox(0, 0, 8, 9)])
+]
+
+
+@pytest.mark.parametrize(
+    "proposed_boxes_unpadded,icon_box_unpadded,icon,image,expected",
+    standardize_padding_tests)
+def test_standardize_bounding_boxes_padding(proposed_boxes_unpadded,
+                                            icon_box_unpadded, icon, image,
+                                            expected):
+  assert algorithms.standardize_bounding_boxes_padding(proposed_boxes_unpadded,
+                                                       icon_box_unpadded, icon,
+                                                       image) == expected


### PR DESCRIPTION
Gold bounding boxes are derived from Material Design’s icons in our dataset. Each of these icons come with this white padding around it, which is included when we draw those gold bounding boxes. There’s not a super easy way to get rid of that white padding. This causes a problem, however, because when we propose bounding boxes, ours are tight around the edges. When we calculate the IOU between a proposed and gold box, we can end up getting an IOU lower than our threshold, even when the two boxes are enclosing the same icon. Here’s an example:  
![Screenshot 2020-08-14 at 7 58 59 PM](https://user-images.githubusercontent.com/10012398/90304041-9d956480-de68-11ea-81ef-8f21a0f156fc.png)

The solution is to add in a padding to our proposed bounding boxes based on the padding ratio in the original template icon. This gets us a proposed bounding box that is much more similar to the gold bounding boxes. Here's the result from the previous example:
![Screenshot 2020-08-14 at 7 58 19 PM](https://user-images.githubusercontent.com/10012398/90304032-90787580-de68-11ea-8df6-12d50abfbf63.png)

Standardized Padding:
- Postprocessing step to add padding to proposed bounding box at the end of the find icon algorithm.
- This is done in the find icon algorithm itself instead of the benchmark pipeline because clients will want bounding boxes, with the padding, just from calling find icon as a stand-alone algorithm.

Testing:
- gpylint passes locally
- Added a unit test for the padding process that tests non-integer padding amounts, image boundaries, different horizontal/vertical padding ratios, etc.