### PR TITLE
Latency Improvements and Memory Updates

### DIFF
--- a/modules/algorithms.py
+++ b/modules/algorithms.py
@@ -14,7 +14,6 @@ from typing import List, Tuple
 import cv2
 from modules.bounding_box import BoundingBox
 import numpy as np
-import sklearn.cluster
 
 # experimentally-derived constants for the precision-recall curve
 _HIGH_PRECISION_MULTIPLIER = 1.5
@@ -70,8 +69,8 @@ def detect_contours(
 
 
 def cluster_contours(
-    clusterer: sklearn.cluster,
-    image_contours: np.ndarray) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+    clusterer,
+    image_contours: np.ndarray) -> List[np.ndarray]:
   """Group contours using the clustering object provided.
 
   Arguments:

--- a/modules/algorithms.py
+++ b/modules/algorithms.py
@@ -14,6 +14,7 @@ from typing import List, Tuple
 import cv2
 from modules.bounding_box import BoundingBox
 import numpy as np
+import sklearn
 
 # experimentally-derived constants for the precision-recall curve
 _HIGH_PRECISION_MULTIPLIER = 1.5
@@ -68,9 +69,8 @@ def detect_contours(
   return image_contours
 
 
-def cluster_contours(
-    clusterer,
-    image_contours: np.ndarray) -> List[np.ndarray]:
+def cluster_contours(clusterer: sklearn.base.ClusterMixin,
+                     image_contours: np.ndarray) -> List[np.ndarray]:
   """Group contours using the clustering object provided.
 
   Arguments:

--- a/modules/benchmark_pipeline.py
+++ b/modules/benchmark_pipeline.py
@@ -1,7 +1,7 @@
 """BenchmarkPipeline class and tfRecord utility functions."""
 
 import argparse
-from typing import Tuple
+from typing import Optional, Tuple
 
 import cv2
 from modules import analysis_util
@@ -9,7 +9,6 @@ from modules import defaults
 from modules import icon_finder
 from modules import util
 from modules.correctness_metrics import CorrectnessMetrics
-from modules.types import OptionalFloat
 import numpy as np
 
 
@@ -31,8 +30,7 @@ class BenchmarkPipeline:
 
     # ----------------------the below are set by algorithm --------------------
     self.proposed_boxes = []  # proposed lists of bounding boxes for each image
-    self.image_clusters = [
-    ]  # list of each image's contour clusters (analysis)
+    self.image_clusters = []  # list of each image's contour clusters(analysis)
     self.icon_contours = []  # list of each template icon's contours (analysis)
     self.correctness_mask = []  # True if no false pos/neg for image (analysis)
 
@@ -187,7 +185,7 @@ class BenchmarkPipeline:
       icon_finder_object: icon_finder.IconFinder = defaults.FIND_ICON_OBJECT,
       output_path: str = defaults.OUTPUT_PATH,
       calc_latency: bool = True,
-      calc_memory: bool = True) -> Tuple[OptionalFloat, OptionalFloat]:
+      calc_memory: bool = True) -> Tuple[Optional[float], Optional[float]]:
     """Runs an icon-finding algorithm, possibly under timed and memory-tracking conditions.
 
     This function will ensure that the results of the icon-finding algorithm are
@@ -243,7 +241,7 @@ class BenchmarkPipeline:
       icon_finder_object: icon_finder.IconFinder = defaults.FIND_ICON_OBJECT,
       multi_instance_icon: bool = False,
       analysis_mode: bool = False,
-  ) -> Tuple[CorrectnessMetrics, OptionalFloat, OptionalFloat]:
+  ) -> Tuple[CorrectnessMetrics, Optional[float], Optional[float]]:
     """Integrated pipeline for testing calculated bounding boxes.
 
     Compares calculated bounding boxes to ground truth,

--- a/modules/benchmark_pipeline.py
+++ b/modules/benchmark_pipeline.py
@@ -3,6 +3,7 @@
 import argparse
 from typing import Tuple
 
+
 import cv2
 from modules import analysis_util
 from modules import defaults
@@ -134,7 +135,12 @@ class BenchmarkPipeline:
         self.image_clusters.append(image_contour_clusters)
         self.icon_contours.append(icon_contour)
       times.append(timer.calculate_latency_info(output_path))
-    print("Average time per image: %f" % np.mean(times))
+    time_info = "Average time per image: %f\n" % np.mean(times)
+    time_info += "Median time of images: %f" % np.median(times)
+    if output_path:
+      with open(output_path, "a") as output_file:
+        output_file.write(time_info)
+    print(time_info)
     return np.mean(times)
 
   def calculate_memory(self, icon_finder_object, output_path: str) -> float:
@@ -168,7 +174,12 @@ class BenchmarkPipeline:
         self.proposed_boxes.append(bboxes)
         self.image_clusters.append(image_contour_clusters)
         self.icon_contours.append(icon_contour)
-    print("Average MiBs per image: %f" % np.mean(mems))
+    memory_info = "Average MiBs per image: %f" % np.mean(mems)
+    memory_info += "Median MiBs per image: %f" % np.median(mems)
+    if output_path:
+      with open(output_path, "a") as output_file:
+        output_file.write(memory_info)
+    print(memory_info)
     return np.mean(mems)
 
   def find_icons(
@@ -267,8 +278,9 @@ class BenchmarkPipeline:
       self.image_list, self.gold_boxes = analysis_util.scale_images_and_bboxes(
           self.image_list, self.gold_boxes, 5, 5)
 
-    avg_runtime_secs, avg_memory_mbs = self.find_icons(icon_finder_object,
-                                                       output_path, True, True)
+    avg_runtime_secs, avg_memory_mbs = self.find_icons(
+        icon_finder_object, output_path, False,
+        True)
     if visualize:
       self.visualize_bounding_boxes("images/" + icon_finder_option + "/" +
                                     icon_finder_option + "-visualized",

--- a/modules/benchmark_pipeline.py
+++ b/modules/benchmark_pipeline.py
@@ -279,7 +279,7 @@ class BenchmarkPipeline:
           self.image_list, self.gold_boxes, 5, 5)
 
     avg_runtime_secs, avg_memory_mbs = self.find_icons(
-        icon_finder_object, output_path, False,
+        icon_finder_object, output_path, True,
         True)
     if visualize:
       self.visualize_bounding_boxes("images/" + icon_finder_option + "/" +

--- a/modules/benchmark_pipeline.py
+++ b/modules/benchmark_pipeline.py
@@ -3,7 +3,6 @@
 import argparse
 from typing import Tuple
 
-
 import cv2
 from modules import analysis_util
 from modules import defaults
@@ -32,7 +31,8 @@ class BenchmarkPipeline:
 
     # ----------------------the below are set by algorithm --------------------
     self.proposed_boxes = []  # proposed lists of bounding boxes for each image
-    self.image_clusters = []  # list of each image's contour clusters (analysis)
+    self.image_clusters = [
+    ]  # list of each image's contour clusters (analysis)
     self.icon_contours = []  # list of each template icon's contours (analysis)
     self.correctness_mask = []  # True if no false pos/neg for image (analysis)
 
@@ -278,9 +278,10 @@ class BenchmarkPipeline:
       self.image_list, self.gold_boxes = analysis_util.scale_images_and_bboxes(
           self.image_list, self.gold_boxes, 5, 5)
 
-    avg_runtime_secs, avg_memory_mbs = self.find_icons(
-        icon_finder_object, output_path, True,
-        True)
+    avg_runtime_secs, avg_memory_mbs = self.find_icons(icon_finder_object,
+                                                       output_path,
+                                                       calc_latency=True,
+                                                       calc_memory=True)
     if visualize:
       self.visualize_bounding_boxes("images/" + icon_finder_option + "/" +
                                     icon_finder_option + "-visualized",

--- a/modules/clustering_algorithms.py
+++ b/modules/clustering_algorithms.py
@@ -13,7 +13,7 @@ class SklearnClusterer(abc.ABC):
     clusterer: object of type sklearn.cluster. All sklearn.cluster objects
      follow the same API (ie, you can call .fit(X) on them).
   """
-  clusterer: sklearn.cluster
+  clusterer = None
 
   def get_clusterer(self):
     return self.clusterer

--- a/modules/clustering_algorithms.py
+++ b/modules/clustering_algorithms.py
@@ -3,6 +3,7 @@
 import abc
 
 import hdbscan
+import sklearn
 import sklearn.cluster
 
 
@@ -10,10 +11,11 @@ class SklearnClusterer(abc.ABC):
   """SklearnClusterer is the base class for clustering classes.
 
   Attributes:
-    clusterer: object of type sklearn.cluster. All sklearn.cluster objects
-     follow the same API (ie, you can call .fit(X) on them).
+    clusterer: object of type sklearn.base.ClusterMixin. All
+     sklearn.base.ClusterMixin objects follow the same API
+     (ie, you can call .fit(X) on them).
   """
-  clusterer = None
+  clusterer: sklearn.base.ClusterMixin
 
   def get_clusterer(self):
     return self.clusterer

--- a/modules/icon_finder_shape_context.py
+++ b/modules/icon_finder_shape_context.py
@@ -1,7 +1,7 @@
 """This module has an IconFinderShapeContext class for finding bounding boxes.
 """
-import multiprocessing
-from typing import List, Tuple
+import multiprocessing  # pytype: disable=pyi-error
+from typing import List, Optional, Tuple
 
 import cv2
 
@@ -9,7 +9,6 @@ from modules import algorithms
 from modules import clustering_algorithms
 from modules.bounding_box import BoundingBox
 import modules.icon_finder
-from modules.types import OptionalTuple
 import numpy as np
 
 
@@ -55,7 +54,7 @@ class IconFinderShapeContext(modules.icon_finder.IconFinder):  # pytype: disable
     self.nms_iou_threshold = nms_iou_threshold
 
   def _get_distance(self, icon_contour_3d: np.ndarray,
-                    image_contour_3d: np.ndarray) -> OptionalTuple:
+                    image_contour_3d: np.ndarray) -> Optional[Tuple]:
     """Calculate distance between icon and image contour.
 
     Arguments:

--- a/modules/types.py
+++ b/modules/types.py
@@ -1,7 +1,0 @@
-"""This modules contains custom pytype types for other modules.
-"""
-
-from typing import Tuple, Union
-
-OptionalFloat = Union[None, float]
-OptionalTuple = Union[None, Tuple]

--- a/modules/types.py
+++ b/modules/types.py
@@ -1,6 +1,7 @@
 """This modules contains custom pytype types for other modules.
 """
 
-from typing import Union
+from typing import Tuple, Union
 
 OptionalFloat = Union[None, float]
+OptionalTuple = Union[None, Tuple]

--- a/modules/util.py
+++ b/modules/util.py
@@ -268,6 +268,7 @@ class MemoryTracker:
 
   def __init__(self):
     self.memory_info = ""
+    self.prev_memory = 0
 
   def run_and_track_memory(self, func_args_tuple) -> Any:
     """Tracks memory usage of a function.
@@ -280,6 +281,7 @@ class MemoryTracker:
     Returns:
         Returns whatever the function returns (could be None)
     """
+    self.prev_memory = memory_profiler.memory_usage()[-1]
     self.memory_info, return_value = memory_profiler.memory_usage(
         func_args_tuple, retval=True)
     return return_value
@@ -295,11 +297,10 @@ class MemoryTracker:
     Returns:
         float -- the MiBs used by the function call
     """
-    average_mb = self.memory_info
-    if len(self.memory_info) > 1:
-      average_mb = np.mean(self.memory_info)
-    output_msg = "Process took %f MiBs \n" % average_mb
+
+    mb_used = np.max(self.memory_info) - self.prev_memory
+    output_msg = "Process took %f MiBs \n" % mb_used
     if output_path:
       with open(output_path, "a") as output_file:
         output_file.write(output_msg)
-    return float(average_mb)
+    return float(mb_used)


### PR DESCRIPTION
Latency Improvements
- Parallelize shape context descriptor distance calculation step by using multiprocessing. This reduces our latency by about 0.5s. (Current latency with algorithm running HDBSCAN is now around 2.2s and with DBSCAN is around 1.5s, down from 3s/1.8s on average respectively.)
- Calculate median latency alongside mean

Memory Updates
- Instead of calculating the total memory used by the process during the icon finder function's execution (which will yield large memory usage -- 4000 MiBs -- for our large dataset and smaller memory usage -- 650 MiBs -- for our small dataset), calculate the *additional auxiliary memory* required by the function during execution. In particular, this will not include the memory needed to store the image. The auxiliary memory used by the algorithm is < 20 MiBs on average/median.
- Calculate median memory usage alongside mean